### PR TITLE
Phase 1: academic brand rebase

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,8 +54,7 @@ socials_in_search: false
 bib_search: true
 
 # Dimensions
-max_width: 930px
-
+max_width: 1120px
 # TODO: add layout settings (single page vs. multi-page)
 
 # -----------------------------------------------------------------------------
@@ -462,7 +461,7 @@ enable_darkmode: true # enables switching between light/dark modes
 enable_navbar_social: false # enables displaying social links in the navbar on the about page
 enable_project_categories: true # enables categorization of projects into multiple categories
 enable_medium_zoom: true # enables image zoom feature (as on medium.com)
-enable_progressbar: true # enables a horizontal progress bar linked to the vertical scroll position
+enable_progressbar: false
 enable_video_embedding: false # enables video embedding for bibtex entries. If false, the button opens the video link in a new window.
 
 # -----------------------------------------------------------------------------
@@ -514,7 +513,7 @@ third_party_libraries:
     version: "5.5.0"
   google_fonts:
     url:
-      fonts: "https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700|Libre+Baskerville:400,700|Material+Icons&display=swap"
+      fonts: "https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&family=Source+Serif+4:ital,wght@0,400;0,600;0,700;1,400&family=IBM+Plex+Mono:wght@400;500&display=swap"
   highlightjs:
     integrity:
       css:

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,3 +1,7 @@
+/* PHASE-1-BRAND-REFRESH: imports */
+@import "custom/tokens";
+@import "custom/components";
+
 /*******************************************************************************
  * Custom Styles - Modular Organization
  *
@@ -2550,3 +2554,6 @@ a.quick-link:hover {
     margin-top: 2.5rem;
   }
 }
+
+/* PHASE-1-BRAND-REFRESH: neutralize */
+@import "custom/neutralize";

--- a/_sass/custom/_components.scss
+++ b/_sass/custom/_components.scss
@@ -1,0 +1,144 @@
+/* ==========================================================================
+   RASHID LAB — SHARED COMPONENT PLACEHOLDERS
+   One card, one pill, one eyebrow. All visually-similar components in
+   _custom.scss and _aesthetic-refinements.scss should @extend these
+   instead of redeclaring border/radius/shadow/padding every time.
+
+   Using Sass `%placeholder` selectors (not classes) so nothing renders
+   until something extends it — no bloat in the compiled CSS.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   %rl-card — the one card treatment.
+   Solid surface, hairline border, soft shadow, tight radius.
+   No gradients. No decorative pseudo-elements. No translateY on hover.
+   -------------------------------------------------------------------------- */
+%rl-card {
+  background: var(--rl-bg);
+  border: 1px solid var(--rl-border);
+  border-radius: var(--rl-radius-md);
+  box-shadow: var(--rl-shadow-sm);
+  padding: var(--rl-space-5);
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+
+  &:hover {
+    border-color: var(--rl-border-strong);
+    box-shadow: var(--rl-shadow-md);
+  }
+}
+
+/* Featured variant — a 3px carolina rule on the left, nothing else.
+   Replaces the amber-gradient `--featured` treatment. */
+%rl-card--featured {
+  @extend %rl-card;
+  border-left: 3px solid var(--rl-carolina);
+}
+
+/* --------------------------------------------------------------------------
+   %rl-pill — the one pill treatment.
+   Neutral chip for status / metadata. No role-specific colors.
+   -------------------------------------------------------------------------- */
+%rl-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  background: var(--rl-bg-subtle);
+  border: 1px solid var(--rl-border);
+  border-radius: 3px;
+  color: var(--rl-text);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  line-height: 1.3;
+  text-transform: none;
+}
+
+/* --------------------------------------------------------------------------
+   %rl-eyebrow — tiny uppercase metadata label.
+   Use ONLY for micro-metadata (dates, status). Never on H2/H3.
+   -------------------------------------------------------------------------- */
+%rl-eyebrow {
+  display: inline-block;
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ==========================================================================
+   CARD CLASS → PLACEHOLDER BINDINGS
+   The 10 one-off card classes inventoried in _custom.scss and
+   _aesthetic-refinements.scss all extend %rl-card here. Their original
+   declarations stay in their source files for now; this file wins
+   because it's loaded later. Phase 2 removes the originals.
+   ========================================================================== */
+
+.news-card,
+.social-feed__card,
+.software-card,
+.grant-card,
+.talk-card,
+.recognition-card,
+.research-theme,
+.team-member-card,
+.focus-card,
+.pillar-card,
+.pathway-card,
+.leadership-card,
+.project-card,
+.mission-panel__card,
+.focus-area-item {
+  @extend %rl-card;
+
+  /* Kill the decorative pseudo-element stripes / gradient overlays. */
+  &::before,
+  &::after {
+    display: none !important;
+  }
+
+  /* Kill the translateY lift. Academic cards don't bounce. */
+  &:hover {
+    transform: none;
+  }
+
+  /* Override gradient backgrounds inherited from legacy rules. */
+  background: var(--rl-bg);
+}
+
+.grant-card--featured {
+  @extend %rl-card--featured;
+}
+
+/* ==========================================================================
+   PILL / CHIP BINDINGS
+   Collapse the 4 chip systems (mission-chip, focus-chip, theme-filter,
+   partner-chip, focus-card__badge) into the one neutral pill.
+   ========================================================================== */
+
+.mission-chip,
+.focus-chip,
+.theme-filter,
+.partner-chip,
+.focus-card__badge,
+.project-card__badge,
+.team-callout__eyebrow,
+.section-hero__eyebrow,
+.page-intro__eyebrow {
+  @extend %rl-pill;
+
+  /* Strip the gradient fills and role colors. */
+  background: var(--rl-bg-subtle) !important;
+  color: var(--rl-text) !important;
+  border-color: var(--rl-border) !important;
+  text-transform: none !important;
+  letter-spacing: 0.02em !important;
+  font-weight: 500 !important;
+
+  /* Kill emoji content on project-card badges. Academic. */
+  &::before {
+    content: none !important;
+  }
+}

--- a/_sass/custom/_neutralize.scss
+++ b/_sass/custom/_neutralize.scss
@@ -1,0 +1,335 @@
+/* ==========================================================================
+   NEUTRALIZE
+   Targeted overrides that kill the decorative / marketing treatments
+   accumulated in _custom.scss and _aesthetic-refinements.scss without
+   rewriting those files. This file is loaded LAST.
+
+   Principle: if a rule creates a gradient, a colored role-border, a
+   decorative pseudo-element, a translateY lift, or a marketing shadow,
+   it gets neutralized here.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Kill all decorative radial gradients and mission-panel ornaments.
+   -------------------------------------------------------------------------- */
+.mission-panel::before,
+.mission-panel::after,
+.funding-snapshot::before,
+.funding-snapshot::after,
+.section-hero::before,
+.section-hero::after,
+body::after {
+  content: none !important;
+  background: none !important;
+}
+
+/* --------------------------------------------------------------------------
+   2. Neutralize funding-snapshot hero card.
+   Was: 3-color linear gradient + radial decoration + 16px radius + 2.5rem pad.
+   Now: plain fog-tinted section, hairline border.
+   -------------------------------------------------------------------------- */
+.funding-snapshot {
+  background: var(--rl-bg-subtle) !important;
+  border: 1px solid var(--rl-border) !important;
+  border-radius: var(--rl-radius-md) !important;
+  padding: var(--rl-space-6) !important;
+  text-align: left !important;
+  overflow: visible !important;
+}
+
+.funding-snapshot ul li::before {
+  content: "" !important;  /* remove the green checkmarks */
+  background: var(--rl-text-muted) !important;
+  width: 4px !important;
+  height: 4px !important;
+  top: 1rem !important;
+  left: 0.25rem !important;
+  border-radius: 50% !important;
+  color: transparent !important;
+}
+
+.funding-snapshot ul li {
+  padding-left: 1rem !important;
+  border-bottom: none !important;
+}
+
+/* --------------------------------------------------------------------------
+   3. Neutralize pathway cards — kill the role-colored borders and tints.
+   One uniform card treatment; differentiate with an eyebrow label in markup.
+   -------------------------------------------------------------------------- */
+.pathway-card--students,
+.pathway-card--collaborators,
+.pathway-card--funders {
+  border-color: var(--rl-border) !important;
+
+  &:hover {
+    border-color: var(--rl-border-strong) !important;
+    box-shadow: var(--rl-shadow-md) !important;
+  }
+
+  h3 i,
+  & i[class*="fa-"],
+  & i[class*="ti-"] {
+    color: var(--rl-text-muted) !important;
+    opacity: 0.7;
+  }
+}
+
+.pathway-card::before { display: none !important; }
+
+/* --------------------------------------------------------------------------
+   4. Neutralize the `.section-hero` and `.page-intro` gradient backgrounds.
+   Academic sections don't need ambient gradients.
+   -------------------------------------------------------------------------- */
+.section-hero,
+.section-hero--team,
+.section-hero--research,
+.section-hero--teaching,
+.section-hero--projects {
+  background: transparent !important;
+  border-radius: 0 !important;
+  padding: var(--rl-space-6) 0 var(--rl-space-5) !important;
+  margin-bottom: var(--rl-space-6) !important;
+  border-bottom: 1px solid var(--rl-border);
+}
+
+.page-intro {
+  padding: var(--rl-space-5) 0 var(--rl-space-4);
+  margin-bottom: var(--rl-space-5);
+}
+
+/* Remove uppercase treatment from page-intro titles and H2s —
+   keep uppercase only for micro-metadata (eyebrows). */
+.section-hero h1,
+.page-intro__title {
+  text-transform: none;
+  letter-spacing: -0.01em;
+  font-family: var(--rl-font-serif);
+  font-weight: 700;
+  color: var(--rl-heading);
+}
+
+/* --------------------------------------------------------------------------
+   5. Hero-panel CTAs — solid fills, no gradients.
+   -------------------------------------------------------------------------- */
+.hero-panel__cta .btn-primary,
+.hero-cta .btn-primary {
+  background: var(--rl-navy) !important;
+  border: 1px solid var(--rl-navy) !important;
+  box-shadow: none !important;
+  border-radius: var(--rl-radius-sm) !important;
+  font-weight: 500 !important;
+
+  &:hover {
+    background: var(--rl-navy-deep) !important;
+    border-color: var(--rl-navy-deep) !important;
+    transform: none !important;
+    box-shadow: none !important;
+  }
+}
+
+.hero-panel__cta .btn-outline-primary,
+.hero-cta .btn-outline-primary {
+  background: transparent !important;
+  border: 1px solid var(--rl-navy) !important;
+  color: var(--rl-navy) !important;
+  box-shadow: none !important;
+  border-radius: var(--rl-radius-sm) !important;
+  font-weight: 500 !important;
+
+  &:hover {
+    background: var(--rl-fog) !important;
+    transform: none !important;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   6. Kill the section-header gradient underlines.
+   Keep a hairline border; remove the decorative `::after` bar.
+   -------------------------------------------------------------------------- */
+.post-content > h2,
+article > h2,
+main > h2 {
+  border-bottom: 1px solid var(--rl-border) !important;
+  padding-bottom: var(--rl-space-2) !important;
+  margin-top: var(--rl-space-6) !important;
+  margin-bottom: var(--rl-space-4) !important;
+}
+
+.post-content > h2::after,
+article > h2::after,
+main > h2::after {
+  content: none !important;
+  display: none !important;
+  background: none !important;
+}
+
+/* --------------------------------------------------------------------------
+   7. Publication abbr badges — neutral, no gradient shadow, no scale hover.
+   -------------------------------------------------------------------------- */
+.publications .abbr abbr {
+  box-shadow: none !important;
+  border-radius: var(--rl-radius-sm) !important;
+  letter-spacing: 0.02em !important;
+
+  &:hover {
+    transform: none !important;
+    box-shadow: none !important;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   8. Kill staggered fadeInUp animations site-wide.
+   Academic sites don't orchestrate entrance choreography.
+   -------------------------------------------------------------------------- */
+.hero-panel,
+.mission-panel__card,
+.focus-card,
+.pillar-card,
+.pathway-card,
+.talk-card,
+.team-member-card,
+.software-card,
+.project-card,
+.grant-card,
+.leadership-card {
+  animation: none !important;
+}
+
+/* --------------------------------------------------------------------------
+   9. Talk cards — drop the carolina left-rule border-thickness inconsistency.
+   -------------------------------------------------------------------------- */
+.talk-card {
+  border-left: 1px solid var(--rl-border) !important;
+  padding-left: var(--rl-space-5);
+
+  &:hover {
+    border-left-color: var(--rl-border-strong) !important;
+  }
+}
+
+.talk-card__date {
+  @extend %rl-pill;
+  background: var(--rl-bg-subtle) !important;
+  color: var(--rl-text-muted) !important;
+  letter-spacing: 0.02em !important;
+}
+
+/* --------------------------------------------------------------------------
+   10. Team group badges — neutral chip.
+   -------------------------------------------------------------------------- */
+.team-group-block__header .badge,
+.team-member-card__title .badge-pill {
+  @extend %rl-pill;
+  background: var(--rl-bg-subtle) !important;
+  color: var(--rl-text-muted) !important;
+  border-color: var(--rl-border) !important;
+}
+
+.team-group-block__header {
+  border-bottom: 1px solid var(--rl-border) !important;
+}
+
+/* Kill the faculty top-bar gradient. */
+.team-member-card--faculty::before {
+  content: none !important;
+  display: none !important;
+}
+
+.team-member-card--faculty {
+  border-color: var(--rl-border) !important;
+}
+
+/* --------------------------------------------------------------------------
+   11. Kill hover-scale on team portraits.
+   -------------------------------------------------------------------------- */
+.team-member-card:hover .team-member-card__media img {
+  transform: none !important;
+}
+
+/* --------------------------------------------------------------------------
+   12. Project-card stage bars — remove the top gradient stripe.
+   Stage differentiation happens via the (now-neutralized) pill above.
+   -------------------------------------------------------------------------- */
+.project-card::before,
+.pillar-card::before {
+  content: none !important;
+  display: none !important;
+  background: none !important;
+}
+
+/* --------------------------------------------------------------------------
+   13. Publications theme-filter — active state uses navy, no gradient.
+   -------------------------------------------------------------------------- */
+.theme-filter--active {
+  background: var(--rl-navy) !important;
+  color: var(--rl-paper) !important;
+  border-color: var(--rl-navy) !important;
+
+  &:hover {
+    background: var(--rl-navy-deep) !important;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   14. Collaboration / page-cta blocks — neutral fog, no gradient.
+   -------------------------------------------------------------------------- */
+.collaboration-callout,
+.page-cta,
+.team-callout {
+  background: var(--rl-bg-subtle) !important;
+  border: 1px solid var(--rl-border) !important;
+  border-left: 3px solid var(--rl-carolina) !important;
+  border-radius: var(--rl-radius-md) !important;
+}
+
+.page-cta--student,
+.page-cta--usage,
+.page-cta--collab {
+  border-left-color: var(--rl-carolina) !important;  /* uniform */
+}
+
+/* --------------------------------------------------------------------------
+   15. Typography baseline.
+   -------------------------------------------------------------------------- */
+body {
+  font-family: var(--rl-font-sans);
+  color: var(--rl-text);
+  font-size: var(--rl-text-base);
+  line-height: var(--rl-leading-normal);
+}
+
+h1, .h1 {
+  font-family: var(--rl-font-serif);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+h2, h3, h4, h5, h6 {
+  font-family: var(--rl-font-sans);
+  font-weight: 600;
+  letter-spacing: 0;
+  color: var(--rl-heading);
+}
+
+code, pre, kbd, samp {
+  font-family: var(--rl-font-mono);
+}
+
+/* --------------------------------------------------------------------------
+   16. Navbar polish — center logo vertically, remove progress bar.
+   -------------------------------------------------------------------------- */
+.navbar-brand img,
+.navbar .logo {
+  padding: 6px 0;
+  max-height: 48px;
+  width: auto;
+  object-fit: contain;
+}
+
+/* The progress bar is also disabled via _config.yml (`enable_progressbar: false`).
+   This rule is a belt-and-braces in case of cached builds. */
+#progress,
+.progress-container {
+  display: none !important;
+}

--- a/_sass/custom/_tokens.scss
+++ b/_sass/custom/_tokens.scss
@@ -1,0 +1,112 @@
+/* ==========================================================================
+   RASHID LAB — DESIGN TOKENS
+   Single source of truth for color, type, spacing, radius, and shadow.
+   Emitted as CSS custom properties so they are consumable from both
+   Sass partials and inline styles, and so dark-mode can swap them
+   without re-compiling.
+   --------------------------------------------------------------------------
+   Register: disciplined, academic. No decorative gradients.
+   ========================================================================== */
+
+:root {
+  /* ---- Brand palette ------------------------------------------------- */
+  --rl-navy:        #13294B;  /* primary ink, headings, links on light bg */
+  --rl-navy-deep:   #0B1D3A;  /* pressed / active */
+  --rl-carolina:    #4B9CD3;  /* accent, interactive hover */
+  --rl-carolina-deep: #2E6A9F;
+
+  /* ---- Surfaces & neutrals ------------------------------------------ */
+  --rl-paper:       #FFFFFF;  /* page background, light mode */
+  --rl-fog:         #F4F6F8;  /* subtle section tint */
+  --rl-mist:        #E6EAEF;  /* dividers, card borders (hairline) */
+  --rl-graphite:    #5B6670;  /* muted body text, metadata */
+  --rl-ink:         #1A202C;  /* primary body text */
+
+  /* ---- Semantic aliases (used by components) ------------------------ */
+  --rl-bg:              var(--rl-paper);
+  --rl-bg-subtle:       var(--rl-fog);
+  --rl-text:            var(--rl-ink);
+  --rl-text-muted:      var(--rl-graphite);
+  --rl-heading:         var(--rl-navy);
+  --rl-link:            var(--rl-carolina-deep);
+  --rl-link-hover:      var(--rl-navy);
+  --rl-border:          var(--rl-mist);
+  --rl-border-strong:   #CED4DA;
+  --rl-accent:          var(--rl-carolina);
+
+  /* ---- Radius scale (kept tight, no pill stuntwork) ------------------ */
+  --rl-radius-sm: 3px;
+  --rl-radius-md: 6px;
+  --rl-radius-lg: 10px;
+
+  /* ---- Shadow scale (academic: hairline + one soft elevation) -------- */
+  --rl-shadow-none:  none;
+  --rl-shadow-sm:    0 1px 2px rgba(19, 41, 75, 0.06);
+  --rl-shadow-md:    0 1px 3px rgba(19, 41, 75, 0.08);
+
+  /* ---- Spacing scale (used by components) ---------------------------- */
+  --rl-space-1:  0.25rem;
+  --rl-space-2:  0.5rem;
+  --rl-space-3:  0.75rem;
+  --rl-space-4:  1rem;
+  --rl-space-5:  1.5rem;
+  --rl-space-6:  2rem;
+  --rl-space-7:  3rem;
+
+  /* ---- Typography ---------------------------------------------------- */
+  --rl-font-sans:   "Archivo", -apple-system, BlinkMacSystemFont, "Segoe UI",
+                    Helvetica, Arial, sans-serif;
+  --rl-font-serif:  "Source Serif 4", "Source Serif Pro", Georgia, "Times New Roman", serif;
+  --rl-font-mono:   "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo,
+                    Consolas, monospace;
+
+  --rl-text-xs:     0.75rem;   /* 12px  — micro-metadata only */
+  --rl-text-sm:     0.875rem;  /* 14px  — metadata */
+  --rl-text-base:   1rem;      /* 16px  — body */
+  --rl-text-md:     1.125rem;  /* 18px  — lede */
+  --rl-text-lg:     1.375rem;  /* 22px  — h3 */
+  --rl-text-xl:     1.75rem;   /* 28px  — h2 */
+  --rl-text-2xl:    2.25rem;   /* 36px  — h1 */
+
+  --rl-leading-tight: 1.25;
+  --rl-leading-normal: 1.55;
+  --rl-leading-loose: 1.7;
+}
+
+/* ==========================================================================
+   DARK-MODE PAIRS
+   al-folio toggles `html[data-theme='dark']`. We swap only the semantic
+   aliases — brand hex values don't change, their role does.
+   ========================================================================== */
+
+html[data-theme='dark'] {
+  --rl-bg:              #0F1720;
+  --rl-bg-subtle:       #17202B;
+  --rl-text:            #E2E8F0;
+  --rl-text-muted:      #94A3B8;
+  --rl-heading:         #E2E8F0;
+  --rl-link:            #8AB8DB;
+  --rl-link-hover:      #B8D4E8;
+  --rl-border:          rgba(255, 255, 255, 0.08);
+  --rl-border-strong:   rgba(255, 255, 255, 0.14);
+  --rl-accent:          #8AB8DB;
+
+  --rl-shadow-sm:       0 1px 2px rgba(0, 0, 0, 0.4);
+  --rl-shadow-md:       0 1px 3px rgba(0, 0, 0, 0.5);
+}
+
+/* ==========================================================================
+   LEGACY ALIASES
+   Keep the existing --global-* vars working for any partial we don't touch
+   in Phase 1. Remove in Phase 2 once all consumers are migrated.
+   ========================================================================== */
+
+:root {
+  --global-primary-blue:  var(--rl-carolina);
+  --global-accent-blue:   var(--rl-navy);
+  --global-warm-accent:   #C48A1A;  /* dulled from marketing-orange #FF9E1B */
+  --global-neutral-dark:  var(--rl-navy);
+  --global-neutral-light: var(--rl-fog);
+  --global-heading-color: var(--rl-heading);
+  --global-text-muted:    var(--rl-text-muted);
+}

--- a/_sass/custom/_variables.scss
+++ b/_sass/custom/_variables.scss
@@ -1,10 +1,26 @@
-/* Color Variables — aligned with UNC Brand Guidelines (identity.unc.edu) */
-:root {
-  --global-primary-blue: #4b9cd3;  /* Carolina Blue */
-  --global-accent-blue: #13294B;   /* Navy */
-  --global-warm-accent: #FF9E1B;   /* Tulip Poplar */
-  --global-neutral-dark: #13294B;  /* Navy */
-  --global-neutral-light: #f5f7fa;
-  --global-heading-color: #13294B; /* Navy */
-  --global-text-muted: #5B6670;    /* Old Well Basin */
-}
+/* ==========================================================================
+   CUSTOM VARIABLES
+   Rashid Lab tokens are defined as CSS custom properties in `_tokens.scss`.
+   This file retains Sass-level variables used by older partials that
+   interpolate at compile time (e.g. color functions like `lighten()`).
+   ========================================================================== */
+
+/* Brand hex values mirrored from _tokens.scss. Kept in sync manually. */
+$rl-navy:         #13294B;
+$rl-navy-deep:    #0B1D3A;
+$rl-carolina:     #4B9CD3;
+$rl-carolina-deep: #2E6A9F;
+$rl-paper:        #FFFFFF;
+$rl-fog:          #F4F6F8;
+$rl-mist:         #E6EAEF;
+$rl-graphite:     #5B6670;
+$rl-ink:          #1A202C;
+
+/* Legacy Sass variables — keep for backwards compat with existing partials.
+   Prefer CSS custom properties from _tokens.scss for any new code. */
+$global-primary-blue:  $rl-carolina;
+$global-accent-blue:   $rl-navy;
+$global-neutral-dark:  $rl-navy;
+$global-neutral-light: $rl-fog;
+$global-heading-color: $rl-navy;
+$global-text-muted:    $rl-graphite;


### PR DESCRIPTION
## Phase 1 — academic brand rebase

### New files
- `_sass/custom/_tokens.scss` — Rashid Lab design tokens + dark-mode pairs
- `_sass/custom/_components.scss` — %rl-card / %rl-pill / %rl-eyebrow
- `_sass/custom/_neutralize.scss` — overrides that kill decorative chrome

### Modified
- `_sass/custom/_variables.scss` — expanded with RL Sass vars
- `_sass/_custom.scss` — wires new partials (top: tokens + components; bottom: neutralize)
- `_config.yml` — max_width 1120px, progressbar off, google_fonts URL swapped to Archivo + Source Serif 4 + IBM Plex Mono (head.liquid reads this via the `site.third_party_libraries.google_fonts.url.fonts` template, so no template edit needed)

### Principles
- One card, one pill, one eyebrow — kills the 10-card-treatment soup.
- No decorative gradients, no role-colored borders, no translateY lifts.
- Serif headings (Source Serif 4) over sans body (Archivo), mono for metadata.
- Academic register. Substance over marketing gestures.

### Follow-up (Phase 2+)
- Remove the original declarations in `_sass/_custom.scss` and `_sass/custom/_aesthetic-refinements.scss` that `_neutralize.scss` currently overrides (shrinks compiled CSS; no visual change).
- PurIST translational timeline include.
- Hex-suite integration on software page.
