### PR TITLE
Phase 4: post-prose typography pass (/research/, /about/, .talk-card)

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -2560,3 +2560,5 @@ a.quick-link:hover {
 
 /* PHASE-2B-HEX-MARKS: import */
 @import "custom/hex-mark";
+
+@import "custom/post-prose";

--- a/_sass/custom/_post-prose.scss
+++ b/_sass/custom/_post-prose.scss
@@ -1,0 +1,224 @@
+/* ==========================================================================
+   POST PROSE — PHASE 4
+   --------------------------------------------------------------------------
+   Phase 2a aligned the INTERIOR typography of .grant-card and .software-card
+   to the RL token system. This partial does the same for the prose body of
+   /research/, /about/, and any other page using `layout: page` / `layout:
+   about` (al-folio wraps content in <div class="post"><article>).
+
+   Scope (deliberately small):
+     - .post article > h2  (section headers)
+     - .post article > h3  (subsection headers)
+     - .post article > p   (body paragraphs)
+     - .post article > ul, > ol  (top-level lists)
+     - .post article a (inline links — token color + hairline underline)
+     - .talk-card h4 / .talk-card p / .talk-card__venue / .talk-card__location
+       (interior of an existing structured component on /about/)
+
+   Loaded AFTER _page-typography.scss so these declarations win on load
+   order. Selectors use the direct-child combinator (`>`) wherever possible
+   so we don't ripple into nested cards (.grant-card, .software-card,
+   .talk-card, .hero-panel) that have their own typography.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   POST PROSE — section + subsection headers
+   -------------------------------------------------------------------------- */
+
+.post > article {
+  /* h2 — section header. Top rule + breathing room above; serif, navy, 28px.
+     Direct-child only so it doesn't catch h2s inside .talk-card or other
+     embedded components. */
+  > h2 {
+    color: var(--rl-heading);
+    font-family: var(--rl-font-serif);
+    font-size: var(--rl-text-xl);    /* 28px */
+    font-weight: 600;
+    line-height: var(--rl-leading-tight);
+    letter-spacing: -0.005em;
+    margin: var(--rl-space-7) 0 var(--rl-space-4);
+    padding-top: var(--rl-space-5);
+    border-top: 1px solid var(--rl-border);
+  }
+
+  /* First h2 doesn't need a top rule — it sits right under the page title. */
+  > h2:first-child,
+  > h2:first-of-type {
+    margin-top: var(--rl-space-5);
+    padding-top: 0;
+    border-top: none;
+  }
+
+  /* h3 — subsection header. Matches grant-card / software-card h3 (22px). */
+  > h3 {
+    color: var(--rl-heading);
+    font-family: var(--rl-font-serif);
+    font-size: var(--rl-text-lg);    /* 22px */
+    font-weight: 600;
+    line-height: var(--rl-leading-tight);
+    letter-spacing: -0.005em;
+    margin: var(--rl-space-6) 0 var(--rl-space-3);
+  }
+
+  /* h4 — sub-subsection (rare in prose, but used inside .talk-card; here
+     we only style the prose-level ones). Source Serif, 18px. */
+  > h4 {
+    color: var(--rl-heading);
+    font-family: var(--rl-font-serif);
+    font-size: var(--rl-text-md);    /* 18px */
+    font-weight: 600;
+    line-height: var(--rl-leading-tight);
+    margin: var(--rl-space-5) 0 var(--rl-space-3);
+  }
+
+  /* Body paragraph. 16px / 1.55, capped at 64ch for readable measure. */
+  > p {
+    color: var(--rl-text);
+    font-family: var(--rl-font-sans);
+    font-size: var(--rl-text-base);
+    line-height: var(--rl-leading-normal);
+    margin: 0 0 var(--rl-space-4);
+    max-width: 64ch;
+    text-wrap: pretty;
+  }
+
+  /* Top-level lists. Drop a touch of vertical rhythm between items. */
+  > ul,
+  > ol {
+    color: var(--rl-text);
+    font-family: var(--rl-font-sans);
+    font-size: var(--rl-text-base);
+    line-height: var(--rl-leading-normal);
+    max-width: 64ch;
+    margin: 0 0 var(--rl-space-5);
+    padding-left: var(--rl-space-5);
+  }
+
+  > ul > li,
+  > ol > li {
+    margin-bottom: var(--rl-space-2);
+  }
+
+  > ul > li:last-child,
+  > ol > li:last-child {
+    margin-bottom: 0;
+  }
+
+  /* Bold inline labels in prose lists (e.g. "**UNC Lineberger**: ...",
+     "**MPI**, ARPA-H ADAPT…"). Keep them in the heading color so they
+     read as the row's leader, but don't shout. */
+  > ul > li > strong:first-child,
+  > ol > li > strong:first-child {
+    color: var(--rl-heading);
+    font-weight: 600;
+  }
+
+  /* Inline links inside prose. Token color + hairline underline-on-hover.
+     Excludes links inside .talk-card / .grant-card / .software-card —
+     those have their own treatment. */
+  > p a,
+  > ul a,
+  > ol a {
+    color: var(--rl-link);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 160ms ease, color 160ms ease;
+  }
+
+  > p a:hover,
+  > ul a:hover,
+  > ol a:hover {
+    color: var(--rl-link-hover);
+    border-bottom-color: currentColor;
+  }
+
+  /* Italicized journal names (often inside <a>) — keep italic, inherit
+     color so they don't fight with the link color. */
+  > p em,
+  > ul em,
+  > ol em {
+    font-style: italic;
+    color: inherit;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   TALK CARD interior  (used on /about/ — Recent Invited Talks)
+   The shell already has %rl-card + a left rule from _neutralize.scss
+   (Phase 1) and the pilled __date from same. This block aligns the
+   remaining pieces — title, venue, location, description — to the token
+   system so the card matches the grant-card / software-card register.
+   -------------------------------------------------------------------------- */
+
+.talk-card {
+  /* Title — match grant-card / software-card h3. */
+  h4 {
+    color: var(--rl-heading);
+    font-family: var(--rl-font-serif);
+    font-size: var(--rl-text-lg);    /* 22px */
+    font-weight: 600;
+    line-height: var(--rl-leading-tight);
+    letter-spacing: -0.005em;
+    margin: var(--rl-space-2) 0 var(--rl-space-2);
+  }
+
+  /* Description paragraph — body register. */
+  p {
+    color: var(--rl-text);
+    font-family: var(--rl-font-sans);
+    font-size: var(--rl-text-base);
+    line-height: var(--rl-leading-normal);
+    margin: 0 0 var(--rl-space-3);
+    max-width: 64ch;
+    text-wrap: pretty;
+  }
+
+  /* Meta row sits cleaner with a small gap; the existing layout is
+     inline-flex via _aesthetic-refinements but the gap was uneven. */
+  &__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: var(--rl-space-2) var(--rl-space-4);
+    margin-bottom: var(--rl-space-2);
+  }
+
+  /* Venue + location → mono eyebrow. Pairs visually with the existing
+     pilled .talk-card__date (which is already %rl-pill-styled). */
+  &__venue,
+  &__location {
+    color: var(--rl-text-muted);
+    font-family: var(--rl-font-mono);
+    font-size: var(--rl-text-xs);
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  /* "Slides" action button keeps token link styling, drops the bootstrap
+     btn-outline-secondary feel. */
+  &__actions a {
+    color: var(--rl-link);
+    font-family: var(--rl-font-mono);
+    font-size: var(--rl-text-xs);
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    text-decoration: none;
+    border: 1px solid var(--rl-border);
+    padding: 0.3rem 0.6rem;
+    border-radius: var(--rl-radius-sm);
+    transition: border-color 160ms ease, color 160ms ease;
+  }
+
+  &__actions a:hover {
+    color: var(--rl-link-hover);
+    border-color: var(--rl-border-strong);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   DARK MODE
+   The token aliases swap inside html[data-theme='dark'], so all the
+   --rl-* references above carry through with no per-rule overrides.
+   -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Phase 4 — post-prose typography pass

Extends the token-driven typography system from `.grant-card` / `.software-card` interiors out to the prose body of every page using `layout: page` / `layout: about` (al-folio wraps content in `<div class="post"><article>`), plus `.talk-card` interior typography.

Pure CSS, no markup changes.

### ⚠ Merge order — depends on #3 (Phase 1)

This branch references CSS custom properties (`--rl-heading`, `--rl-text`, `--rl-link`, `--rl-font-serif`, `--rl-font-sans`, `--rl-text-xl`/`-lg`/`-md`/`-base`, `--rl-leading-tight`/`-normal`, `--rl-space-2` … `--rl-space-7`, `--rl-border`) that are defined in `_sass/custom/_tokens.scss`, which is introduced in **#3 (Phase 1: academic brand rebase)**.

**Do not merge this PR before #3.** If merged first, the prose typography selectors evaluate `var(--rl-*)` to invalid and the declarations silently drop, leaving headings/body in inherited (pre-rebase) styling on `/research/` and `/about/`.

The two branches are textually independent (Phase 1 doesn't touch `_post-prose.scss`; Phase 4 only appends one `@import` line to `_sass/_custom.scss`), so the dependency is semantic, not Git-mechanical.

### Selectors

Use the direct-child combinator (`>`) so styles do not ripple into nested cards (`.grant-card`, `.software-card`, `.talk-card`, `.hero-panel`) that already define their own typography.

| Selector | Treatment |
|---|---|
| `.post article > h2` | Source Serif 4 28px / 600, `--rl-heading`, top hairline rule, breathing room above. First `h2` has no top rule. |
| `.post article > h3` | Source Serif 4 22px / 600. Matches grant-card / software-card `h3`. |
| `.post article > h4` | Source Serif 4 18px / 600. |
| `.post article > p` | Archivo 16px / 1.55, `--rl-text`, max 64ch measure, `text-wrap: pretty`. |
| `.post article > ul, > ol` | 16px / 1.55, max 64ch, tightened item-to-item rhythm. |
| `.post article` inline links | `--rl-link`, hairline underline-on-hover. |
| `.talk-card h4 / p / __venue / __location / __actions` | Match grant-card register: serif title, mono eyebrows for venue/location, body paragraph at 16px, mono uppercase 'Slides' action button. |

### Files

- `_sass/custom/_post-prose.scss` — new (~224 lines)
- `_sass/_custom.scss` — appends `@import "custom/post-prose"`
