### PR TITLE
Phase 2b: hex-mark system + software page integration

### DIFF
--- a/_includes/hex-mark.html
+++ b/_includes/hex-mark.html
@@ -1,0 +1,156 @@
+{%- comment -%}
+  Hex mark — Rashid Lab package identifier.
+
+  Usage:
+    {% include hex-mark.html pkg="BATON"        size="md" %}
+    {% include hex-mark.html pkg="DeSurv"       size="sm" %}
+    {% include hex-mark.html pkg="PurIST"       size="lg" %}
+    {% include hex-mark.html pkg="evolveTrial"  size="md" %}
+
+  Parameters:
+    pkg   — one of: BATON | DeSurv | PurIST | evolveTrial
+    size  — sm | md | lg (default: md)
+
+  Design:
+    Pointy-top R-community sticker (174×200 viewBox, 5:6 ratio matching
+    the 50.8×58.7mm R hex sticker spec). Navy ground, carolina hex
+    outline + hairline inner outline. Each package carries a
+    domain-specific glyph above its wordmark:
+
+      BATON       balanced-spiral conductor's-baton landscape
+      DeSurv      Kaplan–Meier step curve with bias-correction hashes
+      PurIST      paired-gene scatter split by the y=x classifier
+      evolveTrial Monte-Carlo paths with efficacy/futility boundaries
+
+    Wordmark sits in the lower band in Archivo 600. Sticker is identical
+    in light + dark mode (it's a self-contained brand block).
+{%- endcomment -%}
+{%- assign _pkg = include.pkg -%}
+{%- assign _size = include.size | default: "md" -%}
+<span class="hex-mark hex-mark--{{ _size }}" role="img" aria-label="{{ _pkg }} hex sticker">
+  <svg class="hex-mark__shape" viewBox="0 0 174 200" aria-hidden="true" focusable="false">
+    {%- comment -%} ── Shell: navy fill + carolina outline + carolina hairline inner ──{%- endcomment -%}
+    <polygon points="87,2 170,50 170,150 87,198 4,150 4,50" fill="#0B1D3A"/>
+    <polygon points="87,2 170,50 170,150 87,198 4,150 4,50" fill="none"
+             stroke="#4B9CD3" stroke-width="4" stroke-linejoin="round"/>
+    <polygon points="87,10 163,54 163,146 87,190 11,146 11,54" fill="none"
+             stroke="#4B9CD3" stroke-opacity=".35" stroke-width="1"/>
+
+    {%- comment -%} ── Glyph ──{%- endcomment -%}
+    {%- if _pkg == "BATON" -%}
+      {%- comment -%} BATON · balanced-spiral conductor's baton over the objective landscape {%- endcomment -%}
+      <g fill="none" stroke="#4B9CD3" stroke-linejoin="round">
+        <ellipse cx="87" cy="132" rx="46" ry="7"   stroke-opacity=".22" stroke-width="1"/>
+        <ellipse cx="87" cy="130" rx="30" ry="5"   stroke-opacity=".32" stroke-width="1"/>
+        <ellipse cx="87" cy="128" rx="16" ry="2.6" stroke-opacity=".5"  stroke-width="1"/>
+      </g>
+      <path d="M 43 118 C 65 118 75 60 87 60 C 99 60 109 118 131 118"
+            fill="#4B9CD3" fill-opacity=".14"
+            stroke="#4B9CD3" stroke-width="2" stroke-linejoin="round"/>
+      <path d="M 42 126 C 56 150 118 150 138 122 C 158 96 110 76 87 60"
+            fill="none" stroke="#C48A1A" stroke-opacity=".9"
+            stroke-width="1.25" stroke-dasharray="3,2" stroke-linecap="round"/>
+      <g fill="#C48A1A">
+        <circle cx="60"  cy="139" r="1.5"/>
+        <circle cx="122" cy="135" r="1.5"/>
+        <circle cx="121" cy="81"  r="1.5"/>
+      </g>
+      <path d="M 50 34 Q 66 22 87 60" fill="none"
+            stroke="#4B9CD3" stroke-opacity=".4" stroke-width="1" stroke-dasharray="2.5,2.5"/>
+      <line x1="54" y1="42" x2="87" y2="60"
+            stroke="#F4F6F8" stroke-width="2.75" stroke-linecap="round"/>
+      <circle cx="50" cy="40" r="4.25" fill="#C48A1A" stroke="#F4F6F8" stroke-width="1"/>
+      <circle cx="87" cy="60" r="6"  fill="none" stroke="#F4F6F8" stroke-opacity=".35" stroke-width="1"/>
+      <circle cx="87" cy="60" r="3"  fill="#F4F6F8"/>
+      <g stroke="#F4F6F8" stroke-width="1.25" stroke-linecap="round">
+        <line x1="87" y1="52" x2="87" y2="48"/>
+        <line x1="91" y1="55" x2="95" y2="51"/>
+        <line x1="93" y1="60" x2="98" y2="60"/>
+        <line x1="91" y1="65" x2="95" y2="69"/>
+        <line x1="87" y1="68" x2="87" y2="72"/>
+      </g>
+
+    {%- elsif _pkg == "DeSurv" -%}
+      {%- comment -%} DeSurv · Kaplan–Meier step curve + censoring + bias-correction {%- endcomment -%}
+      <line x1="28" y1="38"  x2="28"  y2="134" stroke="#4B9CD3" stroke-opacity=".3" stroke-width="1"/>
+      <line x1="28" y1="134" x2="150" y2="134" stroke="#4B9CD3" stroke-opacity=".3" stroke-width="1"/>
+      <path d="M 28 46 L 52 46 L 52 60 L 74 60 L 74 78 L 98 78 L 98 98 L 122 98 L 122 114 L 150 114"
+            fill="none" stroke="#4B9CD3" stroke-width="2.5" stroke-linejoin="miter" stroke-linecap="round"/>
+      <g stroke="#4B9CD3" stroke-width="1.5" stroke-linecap="round">
+        <line x1="40"  y1="42"  x2="40"  y2="50"/>
+        <line x1="64"  y1="56"  x2="64"  y2="64"/>
+        <line x1="86"  y1="74"  x2="86"  y2="82"/>
+        <line x1="110" y1="94"  x2="110" y2="102"/>
+        <line x1="134" y1="110" x2="134" y2="118"/>
+      </g>
+      <g stroke="#C48A1A" stroke-width="2" stroke-linecap="round">
+        <line x1="52"  y1="62"  x2="52"  y2="70"/>
+        <line x1="74"  y1="80"  x2="74"  y2="88"/>
+        <line x1="98"  y1="100" x2="98"  y2="108"/>
+        <line x1="122" y1="116" x2="122" y2="124"/>
+      </g>
+
+    {%- elsif _pkg == "PurIST" -%}
+      {%- comment -%} PurIST · paired-gene scatter split by y=x kTSP boundary {%- endcomment -%}
+      <line x1="36" y1="30"  x2="36"  y2="134" stroke="#4B9CD3" stroke-opacity=".3" stroke-width="1"/>
+      <line x1="36" y1="134" x2="146" y2="134" stroke="#4B9CD3" stroke-opacity=".3" stroke-width="1"/>
+      <line x1="36" y1="134" x2="140" y2="30"  stroke="#F4F6F8" stroke-opacity=".5" stroke-width="1.5" stroke-dasharray="4,3"/>
+      <g fill="#4B9CD3">
+        <circle cx="54"  cy="44" r="3.25"/>
+        <circle cx="66"  cy="56" r="3.25"/>
+        <circle cx="76"  cy="46" r="3.25"/>
+        <circle cx="80"  cy="64" r="3.25"/>
+        <circle cx="92"  cy="68" r="3.25"/>
+        <circle cx="56"  cy="72" r="3.25"/>
+        <circle cx="102" cy="82" r="3.25"/>
+      </g>
+      <g fill="#C48A1A">
+        <circle cx="96"  cy="110" r="3.25"/>
+        <circle cx="108" cy="98"  r="3.25"/>
+        <circle cx="120" cy="112" r="3.25"/>
+        <circle cx="130" cy="122" r="3.25"/>
+        <circle cx="114" cy="120" r="3.25"/>
+        <circle cx="86"  cy="118" r="3.25"/>
+        <circle cx="134" cy="108" r="3.25"/>
+      </g>
+
+    {%- elsif _pkg == "evolveTrial" -%}
+      {%- comment -%} evolveTrial · Monte-Carlo paths with efficacy/futility boundaries {%- endcomment -%}
+      <line x1="26" y1="132" x2="150" y2="132" stroke="#4B9CD3" stroke-opacity=".3" stroke-width="1"/>
+      <line x1="26" y1="48"  x2="150" y2="48"  stroke="#C48A1A" stroke-opacity=".75" stroke-width="1.25" stroke-dasharray="4,2"/>
+      <line x1="26" y1="112" x2="150" y2="112" stroke="#C48A1A" stroke-opacity=".5"  stroke-width="1.25" stroke-dasharray="4,2"/>
+      <circle cx="28" cy="82" r="2.5" fill="#4B9CD3"/>
+      <g fill="none" stroke-linejoin="round" stroke-linecap="round">
+        <path d="M 28 82 L 50 78 L 72 85 L 94 78 L 116 82 L 138 80"
+              stroke="#4B9CD3" stroke-opacity=".4" stroke-width="1.25"/>
+        <path d="M 28 82 L 50 72 L 72 62 L 94 48"
+              stroke="#4B9CD3" stroke-width="1.75"/>
+        <path d="M 28 82 L 50 90 L 72 100 L 94 112"
+              stroke="#4B9CD3" stroke-opacity=".55" stroke-width="1.25" stroke-dasharray="2,2"/>
+        <path d="M 28 82 L 50 85 L 72 80 L 94 87 L 116 82 L 138 86"
+              stroke="#4B9CD3" stroke-opacity=".4" stroke-width="1.25"/>
+        <path d="M 28 82 L 50 76 L 72 68 L 94 60 L 116 52 L 124 48"
+              stroke="#4B9CD3" stroke-width="1.75"/>
+      </g>
+      <circle cx="94"  cy="48"  r="3.75" fill="#C48A1A"/>
+      <circle cx="124" cy="48"  r="3.75" fill="#C48A1A"/>
+      <circle cx="94"  cy="112" r="3.75" fill="none" stroke="#C48A1A" stroke-width="1.75"/>
+    {%- endif -%}
+
+    {%- comment -%} ── Wordmark band ──{%- endcomment -%}
+    <line x1="30" y1="152" x2="144" y2="152" stroke="#4B9CD3" stroke-opacity=".4" stroke-width="1"/>
+    {%- if _pkg == "evolveTrial" -%}
+      <text x="87" y="166" text-anchor="middle"
+            font-family="Archivo, system-ui, sans-serif" font-size="18" font-weight="600"
+            letter-spacing="1.5" fill="#F4F6F8">{{ _pkg }}</text>
+    {%- elsif _pkg == "BATON" -%}
+      <text x="87" y="166" text-anchor="middle"
+            font-family="Archivo, system-ui, sans-serif" font-size="20" font-weight="600"
+            letter-spacing="3" fill="#F4F6F8">{{ _pkg }}</text>
+    {%- else -%}
+      <text x="87" y="166" text-anchor="middle"
+            font-family="Archivo, system-ui, sans-serif" font-size="20" font-weight="600"
+            letter-spacing="2" fill="#F4F6F8">{{ _pkg }}</text>
+    {%- endif -%}
+  </svg>
+</span>

--- a/_pages/software.md
+++ b/_pages/software.md
@@ -13,7 +13,10 @@ Clinical tools, R packages, and legacy utilities are grouped below with links to
 <h2>Decision Support Tools &amp; Patents</h2>
 <div class="software-grid">
   <article class="software-card">
-    <h3>PurIST Pancreatic Classifier</h3>
+    <div class="software-card__head">
+      <h3>PurIST Pancreatic Classifier</h3>
+      {% include hex-mark.html pkg="PurIST" size="md" %}
+    </div>
     <p>Single-sample PDAC subtype assay used in cooperative trials.</p>
     <ul>
       <li><strong>Patents:</strong>
@@ -34,7 +37,10 @@ Clinical tools, R packages, and legacy utilities are grouped below with links to
 <h2>R Packages</h2>
 <div class="software-grid">
   <article class="software-card">
-    <h3>BATON</h3>
+    <div class="software-card__head">
+      <h3>BATON</h3>
+      {% include hex-mark.html pkg="BATON" size="md" %}
+    </div>
     <p>Bayesian adaptive trial operating-characteristic tuning for platform trials.</p>
     <ul>
       <li><a href="https://github.com/naimurashid/BATON">GitHub</a></li>
@@ -42,7 +48,10 @@ Clinical tools, R packages, and legacy utilities are grouped below with links to
     </ul>
   </article>
   <article class="software-card">
-    <h3>evolveTrial</h3>
+    <div class="software-card__head">
+      <h3>evolveTrial</h3>
+      {% include hex-mark.html pkg="evolveTrial" size="md" %}
+    </div>
     <p>Adaptive monitoring and simulation tools for evolutionary clinical trial designs.</p>
     <ul>
       <li><a href="https://github.com/naimurashid/evolveTrial">GitHub</a></li>
@@ -50,7 +59,10 @@ Clinical tools, R packages, and legacy utilities are grouped below with links to
     </ul>
   </article>
   <article class="software-card">
-    <h3>deSurv</h3>
+    <div class="software-card__head">
+      <h3>deSurv</h3>
+      {% include hex-mark.html pkg="DeSurv" size="md" %}
+    </div>
     <p>De-biased survival estimators pairing flexible ML bases with biomarker-rich trial data.</p>
     <ul>
       <li><a href="https://github.com/naimurashid/DeSurv">GitHub</a></li>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -2557,3 +2557,6 @@ a.quick-link:hover {
 
 /* PHASE-1-BRAND-REFRESH: neutralize */
 @import "custom/neutralize";
+
+/* PHASE-2B-HEX-MARKS: import */
+@import "custom/hex-mark";

--- a/_sass/custom/_hex-mark.scss
+++ b/_sass/custom/_hex-mark.scss
@@ -1,0 +1,75 @@
+/* ==========================================================================
+   HEX MARK — PHASE 2B
+   --------------------------------------------------------------------------
+   Usage in Liquid:
+     {% include hex-mark.html pkg="BATON" size="md" %}
+
+   The include returns:
+     <span class="hex-mark hex-mark--md">
+       <svg class="hex-mark__shape" viewBox="0 0 174 200">…</svg>
+     </span>
+
+   Sticker geometry is pointy-top, 5:6 (R-community convention). All
+   colors are baked into the SVG so it renders identically in light
+   and dark mode — the sticker is a self-contained brand block.
+   ========================================================================== */
+
+.hex-mark {
+  display: inline-block;
+  flex-shrink: 0;
+  line-height: 0;
+  vertical-align: middle;
+}
+
+.hex-mark__shape {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* ---- Sizes ---------------------------------------------------------------
+   Width drives everything — height follows the 174:200 aspect ratio.
+   ------------------------------------------------------------------------- */
+
+.hex-mark--sm  { width: 56px;  }
+.hex-mark--md  { width: 96px;  }
+.hex-mark--lg  { width: 144px; }
+.hex-mark--xl  { width: 200px; }
+
+/* ---- Card placement -----------------------------------------------------
+   Inside a .software-card header, float the hex to the right of the H3.
+   The header should read: [ title ] ............ [ hex ]
+   ------------------------------------------------------------------------- */
+
+.software-card__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--rl-space-4);
+  margin-bottom: var(--rl-space-2);
+
+  h3 {
+    margin: 0;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .hex-mark {
+    margin-top: 2px;       /* optical alignment with cap-height */
+  }
+}
+
+/* ---- Tessellation grid (optional, for the software page hero) ----------
+   A 3-row offset grid that lets the four marks tile cleanly with each
+   other — same R hex geometry, so they share edges.
+   ------------------------------------------------------------------------- */
+
+.hex-mark-grid {
+  position: relative;
+  display: block;
+  margin: var(--rl-space-6) 0;
+}
+
+.hex-mark-grid .hex-mark {
+  position: absolute;
+}


### PR DESCRIPTION
## Phase 2b — hex-mark system

Adds a reusable hex-mark visual treatment as a Liquid include (`_includes/hex-mark.html`) plus its supporting partial (`_sass/custom/_hex-mark.scss`), and integrates it into `_pages/software.md`.

### ⚠ Merge order — depends on #3 (Phase 1)

`_sass/custom/_hex-mark.scss` references `--rl-space-2`, `--rl-space-4`, `--rl-space-6` — custom properties defined in `_sass/custom/_tokens.scss`, which is introduced in **#3 (Phase 1: academic brand rebase)**.

**Do not merge before #3.** If merged first, the affected `gap` / `padding` / `margin` declarations evaluate to invalid and silently drop, leaving the hex-mark layout with default browser spacing on the software page.

Textually independent of #3 — only adds a new partial, a new include, three lines to `_sass/_custom.scss`, and edits `_pages/software.md`.

### Files

- `_includes/hex-mark.html` — new Liquid include (~156 lines)
- `_sass/custom/_hex-mark.scss` — new partial (~75 lines)
- `_sass/_custom.scss` — appends `@import "custom/hex-mark"` (3 lines incl. blank)
- `_pages/software.md` — wires hex marks into the software listing
