### PR TITLE
Phase 2a: page-typography pass (grant + software cards)

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -2562,3 +2562,6 @@ a.quick-link:hover {
 @import "custom/hex-mark";
 
 @import "custom/post-prose";
+
+/* PHASE-2A-PAGE-TYPOGRAPHY */
+@import "custom/page-typography";

--- a/_sass/custom/_page-typography.scss
+++ b/_sass/custom/_page-typography.scss
@@ -1,0 +1,242 @@
+/* ==========================================================================
+   PAGE TYPOGRAPHY — PHASE 2A-LITE
+   --------------------------------------------------------------------------
+   Phase 1 aligned the CONTAINER of .grant-card and .software-card (border,
+   radius, shadow, padding, hover) to %rl-card. This partial aligns the
+   INTERIOR TYPOGRAPHY of those same cards to the RL token system.
+
+   Scope (deliberately small):
+     - .grant-card__header h3 / .grant-card__details / .grant-detail / .grant-card__description
+     - .software-card h3 / .software-card > p / .software-card ul li
+     - .funding-accordion summary  (metadata register, not a card)
+
+   Loaded AFTER _components.scss and AFTER _aesthetic-refinements.scss so
+   these declarations win without !important stuntwork. The only !important
+   uses are where _aesthetic-refinements.scss uses a gradient (gradient →
+   solid needs !important because the original uses `background:` shorthand
+   at the same specificity).
+
+   No new content, no new markup, no new includes. Pure CSS.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   GRANT CARDS  (used on /funding/)
+   -------------------------------------------------------------------------- */
+
+.grant-card {
+  /* Header: grant title. Drop to the RL scale; serif to match body h3. */
+  &__header {
+    /* Keep the flex layout from _aesthetic-refinements.scss — it's fine.
+       Just shrink the bottom margin a touch so the title + details read
+       as one typographic block rather than two. */
+    margin-bottom: var(--rl-space-3);
+
+    h3 {
+      color: var(--rl-heading);
+      font-family: var(--rl-font-serif);
+      font-size: var(--rl-text-lg);    /* 22px */
+      font-weight: 600;                /* serif 700 reads too heavy */
+      line-height: var(--rl-leading-tight);
+      letter-spacing: -0.005em;
+      margin: 0;
+    }
+
+    /* The green "active" badge. Neutralize to a pill. */
+    .badge-success {
+      background: var(--rl-bg-subtle) !important;
+      color: var(--rl-text) !important;
+      border: 1px solid var(--rl-border);
+      font-family: var(--rl-font-mono);
+      font-size: var(--rl-text-xs);
+      font-weight: 500;
+      letter-spacing: 0.02em;
+      text-transform: none;
+      padding: 0.2rem 0.6rem;
+      border-radius: 3px;
+    }
+  }
+
+  /* Details row: total / period / role. Tighten the hairline, widen the
+     gap slightly for legibility at 16px. */
+  &__details {
+    gap: var(--rl-space-5) var(--rl-space-6);
+    margin-bottom: var(--rl-space-4);
+    padding-bottom: var(--rl-space-4);
+    border-bottom: 1px solid var(--rl-border);
+  }
+
+  &__description {
+    color: var(--rl-text);
+    font-family: var(--rl-font-sans);
+    font-size: var(--rl-text-base);    /* 16px, up from 0.95rem */
+    line-height: var(--rl-leading-normal);
+    margin-bottom: 0;
+  }
+}
+
+/* Eyebrow label above each stat (Total / Period / Role). */
+.grant-detail__label {
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Stat value ($28.1M, 05/2025–05/2028, MPI). Mono + tabular-nums so
+   dollar amounts and date ranges align vertically between cards. */
+.grant-detail__value {
+  color: var(--rl-heading);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-base);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+}
+
+/* --------------------------------------------------------------------------
+   SOFTWARE CARDS  (used on /software/)
+   -------------------------------------------------------------------------- */
+
+.software-card {
+  /* Package name. Match grant-card h3 so the two pages feel like one system. */
+  h3 {
+    color: var(--rl-heading);
+    font-family: var(--rl-font-serif);
+    font-size: var(--rl-text-lg);
+    font-weight: 600;
+    line-height: var(--rl-leading-tight);
+    letter-spacing: -0.005em;
+    margin: 0 0 var(--rl-space-2);
+    /* Kill the flex layout from _aesthetic-refinements.scss — the old
+       rule used `display: flex` to line up the gradient dot we already
+       killed in Phase 1. */
+    display: block;
+    gap: 0;
+  }
+
+  /* One-line blurb under the title. */
+  > p {
+    color: var(--rl-text);
+    font-family: var(--rl-font-sans);
+    font-size: var(--rl-text-base);
+    line-height: var(--rl-leading-normal);
+    margin-bottom: var(--rl-space-4);
+  }
+
+  /* Metadata list (patents, papers, code links). Drop the hairline
+     separators between every <li> — they read as a table-of-rules instead
+     of metadata. Indent strong labels so "Patents:", "Key papers:", "Code:"
+     form a readable left column. */
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  ul > li {
+    padding: 0;
+    margin-bottom: var(--rl-space-2);
+    border-bottom: none;        /* was: 1px solid rgba(19,41,75,.05) */
+    color: var(--rl-text);
+    font-family: var(--rl-font-sans);
+    font-size: var(--rl-text-sm);  /* 14px; metadata register */
+    line-height: var(--rl-leading-normal);
+  }
+
+  ul > li:last-child {
+    margin-bottom: 0;
+  }
+
+  ul > li > strong {
+    color: var(--rl-text-muted);
+    font-family: var(--rl-font-mono);
+    font-size: var(--rl-text-xs);
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    margin-right: 0.4rem;
+  }
+
+  /* Nested list inside "Patents:" — un-nest visually by removing extra
+     indent so it reads as a continuation of the metadata row. */
+  ul ul {
+    margin-top: var(--rl-space-2);
+    padding-left: 0;
+  }
+
+  ul ul > li {
+    padding-left: var(--rl-space-3);
+    border-left: 2px solid var(--rl-border);
+    margin-bottom: var(--rl-space-2);
+    font-size: var(--rl-text-sm);
+  }
+
+  ul ul > li > strong {
+    /* Inside the nested patents list, strong is just the patent number —
+       keep it readable, not uppercased. */
+    color: var(--rl-text);
+    font-family: var(--rl-font-sans);
+    font-size: var(--rl-text-sm);
+    font-weight: 600;
+    letter-spacing: 0;
+    text-transform: none;
+    margin-right: 0;
+  }
+
+  /* Links: keep the RL link color, lose the bold. */
+  a {
+    color: var(--rl-link);
+    font-weight: 500;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 160ms ease, color 160ms ease;
+  }
+
+  a:hover {
+    color: var(--rl-link-hover);
+    border-bottom-color: currentColor;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   FUNDING ACCORDION  (the "Completed PI / Core leadership awards" details)
+   Drop the gradient summary background; keep the disclosure triangle.
+   -------------------------------------------------------------------------- */
+
+.funding-accordion {
+  border: 1px solid var(--rl-border);
+  border-radius: var(--rl-radius-md);
+  background: var(--rl-bg);
+
+  & > summary {
+    padding: var(--rl-space-3) var(--rl-space-5);
+    background: var(--rl-bg-subtle) !important;
+    color: var(--rl-heading);
+    font-family: var(--rl-font-sans);
+    font-size: var(--rl-text-base);
+    font-weight: 600;
+    letter-spacing: 0;
+  }
+
+  & > summary:hover {
+    background: var(--rl-fog) !important;
+  }
+
+  & > summary::before {
+    color: var(--rl-text-muted);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   DARK MODE
+   The tokens already swap inside html[data-theme='dark'], so the RL
+   variables above (--rl-heading, --rl-text, etc.) carry through with no
+   per-rule overrides. Only the one badge-success !important needs a
+   nudge so its border doesn't disappear on the dark surface.
+   -------------------------------------------------------------------------- */
+
+html[data-theme='dark'] .grant-card__header .badge-success {
+  border-color: var(--rl-border-strong);
+}


### PR DESCRIPTION
## Phase 2a — page-typography pass

Phase 1 rebuilt the card shells (border, radius, shadow, hover) into a single `%rl-card` placeholder. This PR finishes the job on the **interior** of the two most grant-heavy pages: `/funding/` and `/software/`.

### ⚠ Merge order — depends on #3 (Phase 1)

`_sass/custom/_page-typography.scss` references RL design tokens (`--rl-heading`, `--rl-text`, `--rl-font-serif`, etc.) defined in `_sass/custom/_tokens.scss`, which is introduced in **#3 (Phase 1)**. Do not merge before #3.

### Files

- `_sass/custom/_page-typography.scss` — new (~242 lines)
- `_sass/_custom.scss` — appends `@import "custom/page-typography"` after the Phase 1 neutralize import, so it wins last

### What changes

- Grant-card title + software-card title → Source Serif 4 22px / 600 (was Archivo 18px / 700). The two pages now read as one typographic system.
- Grant-card details (`$28.1M`, `05/2025–05/2028`, `MPI`) → IBM Plex Mono with `font-variant-numeric: tabular-nums` so dollar amounts and date ranges line up vertically between cards.
- Software-card metadata labels (`Patents:` / `Key papers:` / `Code:`) → mono eyebrows; hairlines between every `<li>` removed; nested patents list gets a 2px left rule.
- Funding accordion summary loses its gradient background.

### Out of scope

- No new content, no new includes, no markup changes.
- No PurIST timeline include (deferred — existing card is fine).
- No funding stat-block (deferred — no aggregate numbers asserted in current copy).
