### PR TITLE
Phase 5: system wrap — publications, CV, blog, awards, dark-mode

### DIFF
--- a/BRAND_SYSTEM.md
+++ b/BRAND_SYSTEM.md
@@ -1,0 +1,178 @@
+# Brand System — naimurashid.github.io
+
+This document is the consolidated reference for the typography, color, and
+component system used across the site. It supersedes any inline CSS
+comments and the earlier per-phase design docs.
+
+## Stack
+
+| Layer | What | Where |
+|---|---|---|
+| **Source** | al-folio Jekyll theme | upstream |
+| **Tokens** | CSS custom properties (`--rl-*`) | `_sass/custom/_tokens.scss` |
+| **Type system** | Source Serif 4, Inter, JetBrains Mono via Google Fonts | `_includes/head.html` |
+| **Components** | One SCSS partial per component family | `_sass/custom/_*.scss` |
+| **Theme switch** | `html[data-theme='dark']` rewrites the same tokens | `_tokens.scss` |
+| **Bootstrap** | Still loaded — overridden where needed | upstream `_layouts/default.liquid` |
+
+## Tokens
+
+All defined in `_sass/custom/_tokens.scss`. Light mode at `:root`, dark
+mode under `html[data-theme='dark']`. **Never use a hex literal in any
+component partial — always reference a token.**
+
+### Type tokens
+
+```
+--rl-font-serif:    "Source Serif 4", Georgia, serif      (headings, lede)
+--rl-font-sans:     "Inter", system-ui, sans-serif        (body)
+--rl-font-mono:     "JetBrains Mono", ui-monospace, monospace (eyebrows, chips)
+
+--rl-text-xs:       12px       (eyebrows, chips, table headers)
+--rl-text-sm:       14px       (body small, captions)
+--rl-text-base:     16px       (body default)
+--rl-text-md:       18px       (lede, paper titles)
+--rl-text-lg:       22px       (h3)
+--rl-text-xl:       28px       (h2)
+--rl-text-2xl:      36px       (h1, post title)
+
+--rl-leading-tight:  1.2       (display, headings)
+--rl-leading-normal: 1.55      (body)
+```
+
+### Color tokens
+
+```
+--rl-bg:             page background (white / near-black)
+--rl-bg-subtle:      card / chip / code background
+--rl-border:         hairline rule
+--rl-border-strong:  active hairline (focus, selected)
+
+--rl-text:           body text
+--rl-text-muted:     captions, eyebrows, dates
+--rl-heading:        navy in light, off-white in dark
+
+--rl-link:           link default
+--rl-link-hover:     link hover
+```
+
+### Spacing & shape
+
+```
+--rl-space-1 .. --rl-space-8    4px → 64px geometric scale
+--rl-radius-sm:    4px
+--rl-radius-md:    8px
+--rl-shadow-sm:    one-layer hairline shadow
+```
+
+## Component partials
+
+Each partial scopes its rules under a single root selector — never
+declares bare-tag rules at the document root.
+
+| Partial | Root selector(s) | Phase |
+|---|---|---|
+| `_tokens` | `:root`, `html[data-theme='dark']` | 1 |
+| `_post-prose` | `.post > article > h*, p, ul, …` | 4 |
+| `_software-page` | `.software-page`, `.software-card` | 2c |
+| `_software-detail` | `.software-detail__*` | 2c |
+| `_research-page` | `.research-page`, `.research-grid` | 2a |
+| `_grant-card` | `.grant-card`, `.grant-detail__*` | 2b |
+| `_funding-stats` | `.funding-stats__*` | 2b |
+| `_publications` | `.publications` | 5 |
+| `_award-list` | `.post .award-year`, `.post .award-list` | 5 |
+| `_hero-panel-audit` | `.hero-panel--academic`, `.hero-panel__*` | 5 |
+| `_blog-post` | `.post > article.post-content` | 5 |
+| `_cv-page` | `.cv` | 5 |
+| `_dark-mode` | `html[data-theme='dark'] …` | 5 |
+
+## Typographic registers (use these names in code review)
+
+The system has four canonical registers. Pick one when introducing any
+new text style — don't invent a fifth.
+
+### 1. Display
+- `--rl-font-serif`, `--rl-text-2xl` or `--rl-text-xl`, weight 600,
+  `--rl-leading-tight`, slight negative tracking
+- Used for: page titles, h1, h2, paper titles, section titles
+- Color: `--rl-heading`
+
+### 2. Body
+- `--rl-font-sans`, `--rl-text-base` or `--rl-text-sm`, weight 400,
+  `--rl-leading-normal`
+- Used for: paragraphs, list items, table cells, descriptive prose
+- Color: `--rl-text`
+
+### 3. Lede
+- `--rl-font-serif`, `--rl-text-md`, weight 400, line-height 1.6,
+  measure cap 64ch (75ch on blog posts)
+- Used for: opening paragraphs, hero panel summary, page intros
+- Color: `--rl-text`
+
+### 4. Eyebrow
+- `--rl-font-mono`, `--rl-text-xs`, weight 500,
+  `letter-spacing: 0.08em`, `text-transform: uppercase`
+- Used for: dates, labels, kicker lines, navigation
+- Color: `--rl-text-muted`
+- Visual variants: bare text, bordered chip, full bg pill
+
+## Decision rules for adding new components
+
+1. **Does it already have a register?** If the new thing is text — pick
+   one of the four registers. Don't invent new sizes or weights.
+2. **Does it need a wrapper class?** If the new thing is an inline
+   eyebrow or chip inside existing markdown content (e.g. `award-year`),
+   add a class to the markdown rather than introducing a new selector
+   that depends on `<strong>` or `<em>` semantics.
+3. **Does the partial already exist?** Most partials are scoped to a
+   single page or component family. If the new rule belongs in an
+   existing scope, add it there. Only create a new partial if the rule
+   set is large enough to warrant its own file (~50 lines or more).
+4. **Light + dark.** All new components must work in both themes. If
+   tokens cover it, no extra rule. If a bootstrap default leaks through,
+   add an override under `_dark-mode.scss`.
+
+## Out-of-band: hardcoded hexes
+
+The repo had ~25 hex literals before Phase 1. The remaining instances
+(check via `grep -rn '#[0-9A-Fa-f]\{3,6\}' _sass/custom/`) should always
+be zero. If you see one, replace with the appropriate token.
+
+The only exception is `_tokens.scss` itself, where the tokens are
+*defined* with hex literals.
+
+## Phase history
+
+| Phase | Branch | Scope |
+|---|---|---|
+| 1 | `phase-1-academic-rebase` | Token system + base typography |
+| 2a | `phase-2a-research` | Research page card grid |
+| 2b | `phase-2b-funding` | Grant card + funding-stats inline lede |
+| 2c | `phase-2c-software` | Software page card grid + detail layout |
+| 4 | `phase-4-post-prose` | Post-layout shared prose typography |
+| 5 | `phase-5-system-wrap` | Publications, awards, CV, blog, hero-panel, dark-mode |
+
+Each phase ships as one PR off `master`. Merge in the order above to
+keep token references resolved.
+
+## Testing
+
+```bash
+bundle exec jekyll serve
+```
+
+Visit:
+- `/` (home)
+- `/about/` (hero panel + selected awards + service)
+- `/research/` (interest cards + lede)
+- `/research/<topic>/` (topic detail)
+- `/software/` (software cards)
+- `/software/<package>/` (software detail)
+- `/publications/` (bib entries + venue chips)
+- `/cv/` (CV cards)
+- `/blog/` (post index)
+- `/blog/<any-post>/` (post layout)
+- `/funding/` (grant cards + funding-stats)
+
+Toggle the theme switch on every page. Resize to 600px wide. Print
+preview the CV. None of these should expose untokenized chrome.

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -2567,3 +2567,13 @@ a.quick-link:hover {
 @import "custom/page-typography";
 
 @import "custom/software-card";
+
+@import 'custom/publications';
+
+@import 'custom/award-list';
+
+@import 'custom/hero-panel-audit';
+
+@import 'custom/blog-post';
+
+@import 'custom/cv-page';

--- a/_sass/custom/_award-list.scss
+++ b/_sass/custom/_award-list.scss
@@ -1,0 +1,51 @@
+/* ==========================================================================
+   AWARD LIST — PHASE 5
+   --------------------------------------------------------------------------
+   The "Selected Awards" section on /about/ is a bullet list with year
+   leaders:  **2025** — Gillings Research Excellence Award.
+
+   Phase 4 styled `.post article > ul > li > strong:first-child` as a
+   navy bold leader, but for awards we want a stronger eyebrow register
+   (mono uppercase year, like the grant-detail__label pattern). That
+   needs different markup, so we introduce a dedicated wrapper class:
+
+       <li><span class="award-year">2025</span> Gillings Research Excellence Award</li>
+
+   The class is also reused for any "year + sentence" list (recognition,
+   honors). Apply by editing the markdown directly.
+   ========================================================================== */
+
+.post .award-year {
+  display: inline-block;
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--rl-bg-subtle);
+  border: 1px solid var(--rl-border);
+  border-radius: var(--rl-radius-sm);
+  padding: 0.1rem 0.5rem;
+  margin-right: var(--rl-space-3);
+  vertical-align: 1px;
+  font-variant-numeric: tabular-nums;
+  min-width: 4ch;
+  text-align: center;
+}
+
+/* When the list is exclusively award rows, tighten the row gap so it
+   reads as a structured list, not as a paragraph stack. */
+.post .award-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.post .award-list > li {
+  margin-bottom: var(--rl-space-2);
+  padding-left: 0;
+}
+
+.post .award-list > li::marker {
+  content: none;
+}

--- a/_sass/custom/_blog-post.scss
+++ b/_sass/custom/_blog-post.scss
@@ -1,0 +1,155 @@
+/* ==========================================================================
+   BLOG POST RHYTHM — PHASE 5
+   --------------------------------------------------------------------------
+   _layouts/post.liquid wraps content in:
+
+     <div class="post">
+       <article class="post-content">
+         <div id="markdown-content">
+           {{ content }}
+
+   Phase 4's `.post > article > …` selectors catch this `<article>` too
+   (it's a direct child of .post). But blog posts have different rhythm
+   needs than research/about pages:
+
+     - longer paragraphs → wider measure (75ch instead of 64ch)
+     - more breathing room between section headers
+     - inline code / pre-blocks need styling (not present on research/about)
+
+   This partial overrides the shared selectors specifically for the blog
+   post layout. Scoped via .post > article.post-content so it doesn't
+   leak back into research/about (which use plain <article>).
+   ========================================================================== */
+
+.post > article.post-content {
+  /* Wider measure — long-form prose reads better at 70-75ch. */
+  > p,
+  > ul,
+  > ol,
+  > blockquote {
+    max-width: 75ch;
+  }
+
+  /* Extra breathing room above h2 — blog posts often have many of them. */
+  > h2 {
+    margin-top: var(--rl-space-7);
+  }
+
+  /* h2:first-of-type doesn't get the breathing room, just like research. */
+  > h2:first-of-type {
+    margin-top: var(--rl-space-5);
+  }
+
+  /* Block quotes — italic serif, hairline left rule. */
+  > blockquote {
+    border-left: 2px solid var(--rl-border);
+    padding-left: var(--rl-space-5);
+    margin: var(--rl-space-5) 0;
+    color: var(--rl-text-muted);
+    font-family: var(--rl-font-serif);
+    font-style: italic;
+    font-size: var(--rl-text-md);
+    line-height: 1.6;
+  }
+
+  > blockquote > p {
+    margin-bottom: var(--rl-space-2);
+  }
+
+  /* Inline code + code blocks — token-driven, not bootstrap. */
+  code {
+    background: var(--rl-bg-subtle);
+    color: var(--rl-text);
+    font-family: var(--rl-font-mono);
+    font-size: 0.9em;
+    padding: 0.1em 0.4em;
+    border-radius: var(--rl-radius-sm);
+    border: 1px solid var(--rl-border);
+  }
+
+  > pre {
+    background: var(--rl-bg-subtle);
+    border: 1px solid var(--rl-border);
+    border-radius: var(--rl-radius-sm);
+    padding: var(--rl-space-4);
+    margin: var(--rl-space-4) 0;
+    overflow-x: auto;
+    font-family: var(--rl-font-mono);
+    font-size: var(--rl-text-sm);
+    line-height: var(--rl-leading-normal);
+    max-width: none;     /* override the .post > pre 75ch cap */
+  }
+
+  > pre code {
+    background: transparent;
+    border: none;
+    padding: 0;
+    font-size: inherit;
+  }
+
+  /* Horizontal rule — token hairline. */
+  > hr {
+    border: none;
+    border-top: 1px solid var(--rl-border);
+    margin: var(--rl-space-6) 0;
+  }
+
+  /* Table — academic register. */
+  > table,
+  > div > table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: var(--rl-space-4) 0;
+    font-family: var(--rl-font-sans);
+    font-size: var(--rl-text-sm);
+  }
+
+  th, td {
+    text-align: left;
+    padding: var(--rl-space-2) var(--rl-space-3);
+    border-bottom: 1px solid var(--rl-border);
+    vertical-align: top;
+  }
+
+  th {
+    color: var(--rl-text-muted);
+    font-family: var(--rl-font-mono);
+    font-size: var(--rl-text-xs);
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+}
+
+/* Post header (title + meta on blog posts). */
+.post > .post-header > .post-title {
+  color: var(--rl-heading);
+  font-family: var(--rl-font-serif);
+  font-size: var(--rl-text-2xl);
+  font-weight: 600;
+  line-height: var(--rl-leading-tight);
+  letter-spacing: -0.01em;
+  margin: 0 0 var(--rl-space-2);
+}
+
+.post > .post-header > .post-meta,
+.post > .post-header > .post-tags {
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: var(--rl-space-2);
+}
+
+.post > .post-header > .post-tags a {
+  color: var(--rl-text-muted);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 160ms ease, color 160ms ease;
+}
+
+.post > .post-header > .post-tags a:hover {
+  color: var(--rl-link);
+  border-bottom-color: currentColor;
+}

--- a/_sass/custom/_cv-page.scss
+++ b/_sass/custom/_cv-page.scss
@@ -1,0 +1,128 @@
+/* ==========================================================================
+   CV PAGE — PHASE 5
+   --------------------------------------------------------------------------
+   _layouts/cv.liquid wraps each section in:
+
+     <div class="cv">
+       <div class="card mt-3 p-3">
+         <h3 class="card-title font-weight-medium">{{ entry.title }}</h3>
+         <div>
+           {% include cv/list.liquid OR cv/time_table.liquid OR ... %}
+         </div>
+       </div>
+     </div>
+
+   This partial aligns those classes to the RL token system. Pure CSS.
+   ========================================================================== */
+
+/* CV root container — drop bootstrap card-deck spacing. */
+.cv {
+  display: flex;
+  flex-direction: column;
+  gap: var(--rl-space-5);
+  max-width: 80ch;
+}
+
+/* Section card — match grant-card / software-card shell register. */
+.cv .card {
+  background: var(--rl-bg);
+  border: 1px solid var(--rl-border);
+  border-radius: var(--rl-radius-md);
+  padding: var(--rl-space-5) var(--rl-space-6);
+  margin: 0;
+  box-shadow: var(--rl-shadow-sm);
+}
+
+/* Section title — Source Serif h3 register, with a mono eyebrow rule. */
+.cv .card-title {
+  color: var(--rl-heading);
+  font-family: var(--rl-font-serif);
+  font-size: var(--rl-text-lg);     /* 22px */
+  font-weight: 600;
+  line-height: var(--rl-leading-tight);
+  letter-spacing: -0.005em;
+  margin: 0 0 var(--rl-space-4);
+  padding-bottom: var(--rl-space-3);
+  border-bottom: 1px solid var(--rl-border);
+}
+
+/* Body of each card — inherit token typography. */
+.cv .card > div {
+  color: var(--rl-text);
+  font-family: var(--rl-font-sans);
+  font-size: var(--rl-text-sm);
+  line-height: var(--rl-leading-normal);
+}
+
+/* time_table layout — al-folio renders a year column + body column.
+   Dates become mono eyebrows with tabular-nums alignment. */
+.cv table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--rl-text-sm);
+}
+
+.cv table th,
+.cv table td {
+  text-align: left;
+  padding: var(--rl-space-2) var(--rl-space-3);
+  border-bottom: 1px solid var(--rl-border);
+  vertical-align: top;
+}
+
+.cv table th {
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.cv table .date,
+.cv table td:first-child {
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+/* CV lists — token-driven bullet rhythm. */
+.cv ul,
+.cv ol {
+  margin: 0 0 var(--rl-space-3);
+  padding-left: var(--rl-space-5);
+}
+
+.cv ul > li,
+.cv ol > li {
+  margin-bottom: var(--rl-space-2);
+}
+
+/* Inline links inside CV cards — token color, hairline underline. */
+.cv a {
+  color: var(--rl-link);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 160ms ease, color 160ms ease;
+}
+
+.cv a:hover {
+  color: var(--rl-link-hover);
+  border-bottom-color: currentColor;
+}
+
+/* PDF download anchor on the page header. */
+.post-title a[href$=".pdf"] {
+  color: var(--rl-text-muted);
+  font-size: var(--rl-text-md);
+  margin-left: var(--rl-space-3);
+}
+
+.post-title a[href$=".pdf"]:hover {
+  color: var(--rl-link);
+}

--- a/_sass/custom/_dark-mode.scss
+++ b/_sass/custom/_dark-mode.scss
@@ -1,362 +1,121 @@
-/* Dark Mode Overrides */
-html[data-theme="dark"] {
-  --global-heading-color: #e2e8f0;
-  --global-text-muted: #7d8a9a;
-  --global-neutral-dark: #e2e8f0;
-  --global-neutral-light: #1e293b;
-  --global-accent-blue: #60a5fa;
+/* ==========================================================================
+   DARK MODE HYGIENE — PHASE 5
+   --------------------------------------------------------------------------
+   The token aliases in _tokens.scss already swap inside html[data-theme='dark'],
+   so most components carry through with no per-rule overrides. This partial
+   is the catch-all for spots where:
 
-  /* Hero panel border in dark mode */
-  .hero-panel {
-    border-bottom-color: rgba(255, 255, 255, 0.1);
+     - the source uses a hardcoded hex literal that doesn't swap
+     - bootstrap chrome leaks through (badge backgrounds, btn hover states)
+     - a gradient was neutralized to a solid in light mode but the solid
+       still reads wrong against dark surfaces
+
+   Loaded LAST so it wins on cascade.
+   ========================================================================== */
+
+html[data-theme='dark'] {
+
+  /* --------------------------------------------------------------------
+     Publications page — bib entries
+     -------------------------------------------------------------------- */
+  .publications .links .btn {
+    background: var(--rl-bg) !important;
+    color: var(--rl-text-muted) !important;
+    border-color: var(--rl-border) !important;
   }
 
-  /* Standard card backgrounds and borders */
-  .section-hero,
-  .focus-card,
-  .pillar-card,
-  .mission-panel,
-  .news-card,
-  .social-feed__card,
-  .grant-card,
-  .team-member-card,
-  .project-card,
-  .team-group-block,
-  .talk-card,
-  .collaboration-callout,
-  .publication-highlights__card {
-    background: var(--global-card-bg-color);
-    border-color: var(--global-card-border-color);
+  .publications .links .btn:hover {
+    color: var(--rl-link) !important;
+    border-color: var(--rl-border-strong) !important;
   }
 
-  /* Publication cards have left accent border */
-  .publication-highlights__card {
-    border-left-color: #60a5fa;
+  .publications .abbr abbr.badge {
+    background: var(--rl-bg-subtle) !important;
+    color: var(--rl-text-muted) !important;
+    border-color: var(--rl-border) !important;
   }
 
-  /* Muted text elements */
-  .hero-panel__lead,
-  .section-hero__lede,
-  .page-intro__lede,
-  .news-card__date,
-  .news-card__summary,
-  .social-feed__title a,
-  .social-feed__summary,
-  .social-feed__date,
-  .grant-card__description,
-  .page-intro ul li {
-    color: var(--global-text-muted);
+  .publications .row + .row {
+    border-top-color: var(--rl-border);
   }
 
-  /* Metric badges with darker background */
-  .metric,
-  .section-metrics .metric {
-    background: #334155;
-    border-color: var(--global-card-border-color);
+  /* --------------------------------------------------------------------
+     Hero panel — social link chips
+     -------------------------------------------------------------------- */
+  .hero-panel__links--grid .hero-panel__link {
+    background: var(--rl-bg-subtle);
+    border-color: var(--rl-border);
+    color: var(--rl-text-muted);
   }
 
-  /* Gradient backgrounds */
-  .page-intro {
-    background: linear-gradient(120deg, rgba(30, 41, 59, 0.95), rgba(51, 65, 85, 0.95));
-    border-color: var(--global-card-border-color);
+  .hero-panel__links--grid .hero-panel__link:hover {
+    color: var(--rl-link);
+    border-color: var(--rl-border-strong);
   }
 
-  .team-callout {
-    background: linear-gradient(135deg, rgba(30, 41, 59, 0.95), rgba(51, 65, 85, 0.95));
-    border-color: var(--global-card-border-color);
+  /* --------------------------------------------------------------------
+     CV cards
+     -------------------------------------------------------------------- */
+  .cv .card {
+    background: var(--rl-bg);
+    border-color: var(--rl-border);
+    box-shadow: var(--rl-shadow-sm);
   }
 
-  .mission-panel__card {
-    background: rgba(51, 65, 85, 0.9);
-    border-color: var(--global-card-border-color);
+  /* --------------------------------------------------------------------
+     Award eyebrow chip
+     -------------------------------------------------------------------- */
+  .post .award-year {
+    background: var(--rl-bg-subtle);
+    border-color: var(--rl-border);
+    color: var(--rl-text-muted);
   }
 
-  /* Chip and badge styles */
-  .focus-chip,
-  .mission-chip {
-    background: rgba(96, 165, 250, 0.15);
-    border-color: rgba(96, 165, 250, 0.3);
-    color: #e2e8f0;
+  /* --------------------------------------------------------------------
+     Code blocks (blog posts)
+     -------------------------------------------------------------------- */
+  .post > article.post-content code,
+  .post > article.post-content > pre {
+    background: var(--rl-bg-subtle);
+    border-color: var(--rl-border);
+    color: var(--rl-text);
   }
 
-  /* Headings and text in cards */
-  .grant-detail__value,
-  .team-member-card__role,
-  .team-member-card__teaser,
-  .team-member-card__title a,
-  .project-card h3,
-  .project-card p,
-  .project-meta,
-  .project-meta strong,
-  .project-card__badge,
-  .talk-card h4 {
-    color: #e2e8f0;
+  /* --------------------------------------------------------------------
+     al-folio default chrome — these classes appear in many places and
+     the upstream defaults have hardcoded light backgrounds.
+     -------------------------------------------------------------------- */
+  .badge {
+    background: var(--rl-bg-subtle) !important;
+    color: var(--rl-text-muted) !important;
+    border-color: var(--rl-border) !important;
   }
 
-  /* Logo swap for dark mode */
-  .site-logo--light {
-    display: none;
+  .post > .post-header > .post-meta,
+  .post > .post-header > .post-tags {
+    color: var(--rl-text-muted);
   }
 
-  .site-logo--dark {
-    display: block;
+  /* Block quotes inherit token border + muted text. */
+  .post > article > blockquote,
+  .post > article.post-content > blockquote {
+    border-left-color: var(--rl-border);
+    color: var(--rl-text-muted);
   }
 
-  /* Project card badges - lighter colors for dark mode */
-  .project-card__badge--develop {
-    background: rgba(56, 189, 248, 0.25);
-    color: #7dd3fc;
+  /* Tables. */
+  .post > article > table th,
+  .post > article.post-content > table th,
+  .post > article.post-content > div > table th {
+    color: var(--rl-text-muted);
   }
 
-  .project-card__badge--pilot {
-    background: rgba(251, 191, 36, 0.25);
-    color: #fcd34d;
-  }
-
-  .project-card__badge--adopt {
-    background: rgba(134, 239, 172, 0.25);
-    color: #86efac;
-  }
-
-  .project-card__badge--story {
-    background: rgba(191, 219, 254, 0.25);
-    color: #93c5fd;
-  }
-
-  /* Bootstrap badges - better contrast for dark mode */
-  .badge-primary {
-    background-color: #3b82f6 !important;
-    color: #fff !important;
-  }
-
-  .badge-success {
-    background-color: #10b981 !important;
-    color: #fff !important;
-  }
-
-  .badge-info {
-    background-color: #06b6d4 !important;
-    color: #fff !important;
-  }
-
-  /* Funding timeline - dark backgrounds */
-  .timeline-stat {
-    background: #334155;
-    border-color: var(--global-card-border-color);
-    color: #e2e8f0;
-  }
-
-  .timeline-milestone {
-    background: #1e293b;
-    border-color: var(--global-card-border-color);
-  }
-
-  .milestone-title {
-    color: #e2e8f0;
-  }
-
-  .milestone-desc,
-  .milestone-highlight {
-    color: var(--global-text-muted);
-  }
-
-  /* Section headings in alt sections */
-  .page-section--alt h2,
-  .page-section--alt h3,
-  .page-section--alt h4 {
-    color: var(--global-text-muted) !important;
-  }
-
-  /* Featured Publications heading specifically */
-  .page-section--alt > h2 {
-    color: var(--global-text-muted) !important;
-  }
-
-  /* All paragraphs in alt sections */
-  .page-section--alt p {
-    color: var(--global-text-muted) !important;
-  }
-
-  .page-section--alt > p {
-    color: var(--global-text-muted) !important;
-  }
-
-  /* Software list */
-  .software-list li {
-    color: var(--global-text-muted);
-  }
-
-  .software-list strong {
-    color: #e2e8f0;
-  }
-
-  /* Software and grant cards */
-  .software-card h3,
-  .grant-card h3 {
-    color: #e2e8f0;
-  }
-
-  .software-card p,
-  .software-card li {
-    color: var(--global-text-muted);
-  }
-
-  /* Publication highlights */
-  .publication-highlights__card {
-    background: var(--global-card-bg-color);
-    border-color: var(--global-card-border-color);
-  }
-
-  .publication-highlights__card h3,
-  .publication-highlights__card h4 {
-    color: #e2e8f0;
-  }
-
-  /* Research themes and network grids */
-  .research-theme,
-  .network-grid .pillar-card {
-    background: var(--global-card-bg-color);
-    border-color: var(--global-card-border-color);
-  }
-
-  .research-theme h3,
-  .research-theme h4,
-  .network-grid .pillar-card h4 {
-    color: #e2e8f0;
-  }
-
-  .research-theme p,
-  .network-grid .pillar-card p {
-    color: var(--global-text-muted);
-  }
-
-  /* Funding highlights */
-  .funding-highlight {
-    background: var(--global-card-bg-color);
-    border-color: var(--global-card-border-color);
-  }
-
-  .funding-highlight h3 {
-    color: #e2e8f0;
-  }
-
-  .funding-highlight p {
-    color: var(--global-text-muted);
-  }
-
-  .funding-highlights li {
-    color: var(--global-text-muted);
-  }
-
-  /* Page CTAs */
-  .page-cta {
-    background: linear-gradient(135deg, rgba(30, 41, 59, 0.95), rgba(51, 65, 85, 0.95));
-    border-color: var(--global-card-border-color);
-  }
-
-  .page-cta p,
-  .page-cta strong {
-    color: #e2e8f0;
-  }
-
-  /* Teaching and impact sections */
-  .teaching-philosophy,
-  .impact-highlights {
-    color: var(--global-text-muted);
-  }
-
-  .teaching-philosophy h2,
-  .teaching-philosophy h3,
-  .impact-highlights h2,
-  .impact-highlights h3 {
-    color: #e2e8f0;
-  }
-
-  /* Pillar cards (cross-cutting innovations, collaborative network) */
-  .pillar-card {
-    background: var(--global-card-bg-color);
-    border-color: var(--global-card-border-color);
-  }
-
-  .pillar-card h3,
-  .pillar-card h4 {
-    color: #e2e8f0;
-  }
-
-  .pillar-card p {
-    color: var(--global-text-muted);
-  }
-
-  /* Leadership cards */
-  .leadership-card,
-  .leadership-grid .leadership-card {
-    background: var(--global-card-bg-color);
-    border-color: var(--global-card-border-color);
-  }
-
-  .leadership-card h3,
-  .leadership-card h4,
-  .leadership-details p strong {
-    color: #e2e8f0;
-  }
-
-  .leadership-card p,
-  .leadership-card li {
-    color: var(--global-text-muted);
-  }
-
-  /* Diagram wrapper and research portfolio map */
-  .diagram-wrapper {
-    background: transparent;
-  }
-
-  /* All list items in page sections */
-  .page-section ul li,
-  .page-section ol li {
-    color: var(--global-text-muted);
-  }
-
-  .page-section ul li strong,
-  .page-section ol li strong {
-    color: #e2e8f0;
-  }
-
-  /* Funding accordion content */
-  .funding-accordion summary {
-    color: #e2e8f0;
-  }
-
-  .funding-list h4 {
-    color: #e2e8f0;
-  }
-
-  .funding-list p {
-    color: var(--global-text-muted);
-  }
-
-  /* Impact Highlights cards on Publications page */
-  .bg-white {
-    background-color: var(--global-card-bg-color) !important;
-  }
-
-  .text-muted {
-    color: var(--global-text-muted) !important;
-  }
-
-  .shadow-sm {
-    box-shadow: var(--global-shadow-sm) !important;
-  }
-
-  .display-6 {
-    color: #e2e8f0 !important;
-  }
-
-  /* Ensure all p elements in white bg cards are readable */
-  .bg-white p:not(.text-muted) {
-    color: var(--global-text-muted);
-  }
-
-  .bg-white .text-uppercase {
-    color: #94a3b8;
+  .post > article > table td,
+  .post > article > table th,
+  .post > article.post-content > table td,
+  .post > article.post-content > table th,
+  .post > article.post-content > div > table td,
+  .post > article.post-content > div > table th {
+    border-bottom-color: var(--rl-border);
   }
 }

--- a/_sass/custom/_hero-panel-audit.scss
+++ b/_sass/custom/_hero-panel-audit.scss
@@ -1,0 +1,159 @@
+/* ==========================================================================
+   HERO-PANEL AUDIT — PHASE 5
+   --------------------------------------------------------------------------
+   The .hero-panel--academic block on /about/ was styled before the RL
+   token system landed; it uses hex literals for navy / muted / accent and
+   has its own font-size scale that pre-dates --rl-text-*.
+
+   This partial is a hygiene pass: align the hero-panel to the same tokens
+   as the rest of the system, without redesigning the layout. No change
+   to grid, columns, image sizing, or social-link grid.
+   ========================================================================== */
+
+.hero-panel--academic {
+  background: var(--rl-bg);
+  border: 1px solid var(--rl-border);
+  border-radius: var(--rl-radius-md);
+  box-shadow: var(--rl-shadow-sm);
+}
+
+/* --------------------------------------------------------------------------
+   Headline + lead paragraph
+   -------------------------------------------------------------------------- */
+.hero-panel__tagline {
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: var(--rl-space-3);
+}
+
+.hero-panel__lead {
+  color: var(--rl-text);
+  font-family: var(--rl-font-serif);
+  font-size: var(--rl-text-md);     /* 18px lede */
+  font-weight: 400;
+  line-height: 1.6;
+  max-width: 64ch;
+  text-wrap: pretty;
+  margin: 0 0 var(--rl-space-5);
+}
+
+.hero-panel__lead a {
+  color: var(--rl-link);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 160ms ease, color 160ms ease;
+}
+
+.hero-panel__lead a:hover {
+  color: var(--rl-link-hover);
+  border-bottom-color: currentColor;
+}
+
+/* --------------------------------------------------------------------------
+   "Research interests:" + "Training:" inline metadata blocks
+   Sans body text with a mono eyebrow on the bold leader.
+   -------------------------------------------------------------------------- */
+.hero-panel__interests,
+.hero-panel__education {
+  color: var(--rl-text);
+  font-family: var(--rl-font-sans);
+  font-size: var(--rl-text-sm);
+  line-height: var(--rl-leading-normal);
+  max-width: 70ch;
+  margin: 0 0 var(--rl-space-3);
+}
+
+.hero-panel__interests > strong,
+.hero-panel__education > strong {
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-right: var(--rl-space-2);
+}
+
+/* --------------------------------------------------------------------------
+   Inline link cluster (Research · CV · Publications)
+   -------------------------------------------------------------------------- */
+.hero-panel__links-inline {
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-top: var(--rl-space-4);
+  color: var(--rl-text-muted);
+}
+
+.hero-panel__links-inline a {
+  color: var(--rl-link);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 160ms ease, color 160ms ease;
+}
+
+.hero-panel__links-inline a:hover {
+  color: var(--rl-link-hover);
+  border-bottom-color: currentColor;
+}
+
+/* --------------------------------------------------------------------------
+   Aside — name, position, address, social icon grid.
+   -------------------------------------------------------------------------- */
+.hero-panel__name {
+  color: var(--rl-heading);
+  font-family: var(--rl-font-serif);
+  font-size: var(--rl-text-md);
+  font-weight: 600;
+  margin: 0 0 var(--rl-space-1);
+}
+
+.hero-panel__position {
+  color: var(--rl-text);
+  font-family: var(--rl-font-sans);
+  font-size: var(--rl-text-sm);
+  line-height: var(--rl-leading-normal);
+  margin-bottom: var(--rl-space-3);
+}
+
+.hero-panel__address {
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-sans);
+  font-size: var(--rl-text-sm);
+  line-height: var(--rl-leading-normal);
+  margin-bottom: var(--rl-space-4);
+}
+
+/* Social icon links — uniform mono chips. */
+.hero-panel__links--grid .hero-panel__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  background: var(--rl-bg-subtle);
+  border: 1px solid var(--rl-border);
+  border-radius: var(--rl-radius-sm);
+  padding: 0.3rem 0.6rem;
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: border-color 160ms ease, color 160ms ease;
+}
+
+.hero-panel__links--grid .hero-panel__link:hover {
+  color: var(--rl-link);
+  border-color: var(--rl-border-strong);
+}
+
+.hero-panel__links--grid .hero-panel__link i {
+  font-size: 1.1em;
+  color: inherit;
+}

--- a/_sass/custom/_publications.scss
+++ b/_sass/custom/_publications.scss
@@ -1,0 +1,207 @@
+/* ==========================================================================
+   PUBLICATIONS — PHASE 5
+   --------------------------------------------------------------------------
+   al-folio's _layouts/bib.liquid renders each publication as:
+
+     <div class="row">
+       <div class="col-sm-2 abbr">           <abbr class="badge">…</abbr>  (venue chip + thumbnail)
+       <div class="col-sm-8 OR -10">         (entry body)
+         <div class="title">…</div>
+         <div class="author">…</div>          <em>self</em>, <a>coauthor</a>, …
+         <div class="periodical">…</div>      <em>Journal Name</em>, Year
+         <div class="links">                  bootstrap btn-sm chips: PDF / arXiv / Code / …
+           <a class="btn btn-sm">PDF</a>
+         </div>
+       </div>
+     </div>
+
+   This partial aligns those classes to the RL token system. Pure CSS.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   Title — paper title is the dominant element. Serif, navy, h3-scale.
+   -------------------------------------------------------------------------- */
+.publications .title {
+  color: var(--rl-heading);
+  font-family: var(--rl-font-serif);
+  font-size: var(--rl-text-md);     /* 18px */
+  font-weight: 600;
+  line-height: var(--rl-leading-tight);
+  letter-spacing: -0.005em;
+  margin: 0 0 var(--rl-space-1);
+}
+
+/* --------------------------------------------------------------------------
+   Author line — small, sans, --rl-text-muted. Self-author (the <em>) lifts
+   to --rl-heading so my own name reads first.
+   -------------------------------------------------------------------------- */
+.publications .author {
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-sans);
+  font-size: var(--rl-text-sm);
+  font-weight: 400;
+  line-height: var(--rl-leading-normal);
+  margin: 0 0 var(--rl-space-1);
+}
+
+.publications .author em {
+  color: var(--rl-heading);
+  font-style: normal;
+  font-weight: 600;
+}
+
+.publications .author a {
+  color: var(--rl-link);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 160ms ease, color 160ms ease;
+}
+
+.publications .author a:hover {
+  color: var(--rl-link-hover);
+  border-bottom-color: currentColor;
+}
+
+.publications .more-authors {
+  color: var(--rl-link);
+  cursor: pointer;
+  border-bottom: 1px dotted var(--rl-link);
+}
+
+/* --------------------------------------------------------------------------
+   Periodical — journal name + year. <em> is the journal; serif italic so
+   it carries the academic register.
+   -------------------------------------------------------------------------- */
+.publications .periodical {
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-sans);
+  font-size: var(--rl-text-sm);
+  line-height: var(--rl-leading-normal);
+  margin: 0 0 var(--rl-space-2);
+}
+
+.publications .periodical em {
+  color: var(--rl-text);
+  font-family: var(--rl-font-serif);
+  font-style: italic;
+  font-weight: 500;
+}
+
+/* --------------------------------------------------------------------------
+   Venue chip — the .abbr column shows a venue badge (JASA / NEJM / etc).
+   Neutralize the bootstrap badge gradient/color into a mono chip.
+   -------------------------------------------------------------------------- */
+.publications .abbr abbr.badge {
+  background: var(--rl-bg-subtle) !important;
+  color: var(--rl-text-muted) !important;
+  border: 1px solid var(--rl-border);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: var(--rl-radius-sm) !important;
+  padding: 0.25rem 0.5rem;
+}
+
+.publications .abbr abbr.badge a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* --------------------------------------------------------------------------
+   Link buttons — al-folio uses bootstrap btn-sm for PDF / arXiv / Code
+   chips. Replace with the same neutral mono chip used elsewhere.
+   -------------------------------------------------------------------------- */
+.publications .links {
+  margin-top: var(--rl-space-2);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--rl-space-2);
+}
+
+.publications .links .btn {
+  background: var(--rl-bg) !important;
+  color: var(--rl-text-muted) !important;
+  border: 1px solid var(--rl-border) !important;
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.6rem;
+  border-radius: var(--rl-radius-sm);
+  box-shadow: none;
+  transition: border-color 160ms ease, color 160ms ease;
+}
+
+.publications .links .btn:hover {
+  color: var(--rl-link) !important;
+  border-color: var(--rl-border-strong) !important;
+}
+
+.publications .links .btn.award {
+  background: var(--rl-bg-subtle) !important;
+  color: var(--rl-heading) !important;
+  border-color: var(--rl-border-strong) !important;
+}
+
+/* --------------------------------------------------------------------------
+   Year-group headers (al-folio renders bib entries grouped by year as h2).
+   Match .post > article > h2 register.
+   -------------------------------------------------------------------------- */
+.publications h2.year {
+  color: var(--rl-heading);
+  font-family: var(--rl-font-serif);
+  font-size: var(--rl-text-xl);
+  font-weight: 600;
+  line-height: var(--rl-leading-tight);
+  letter-spacing: -0.005em;
+  margin: var(--rl-space-7) 0 var(--rl-space-4);
+  padding-top: var(--rl-space-5);
+  padding-bottom: 0;
+  border-top: 1px solid var(--rl-border);
+  border-bottom: none;
+}
+
+.publications h2.year:first-of-type {
+  margin-top: var(--rl-space-5);
+  padding-top: 0;
+  border-top: none;
+}
+
+/* --------------------------------------------------------------------------
+   Row spacing — drop the heavy bootstrap row gutter, use token spacing.
+   -------------------------------------------------------------------------- */
+.publications .row {
+  margin: 0 0 var(--rl-space-5);
+  padding: 0;
+}
+
+.publications .row + .row {
+  border-top: 1px solid var(--rl-border);
+  padding-top: var(--rl-space-5);
+}
+
+/* --------------------------------------------------------------------------
+   Hidden expansion blocks (Abs / Bib) — when toggled visible, give them
+   a token-driven container instead of the raw bootstrap card-bg.
+   -------------------------------------------------------------------------- */
+.publications .abstract:not(.hidden),
+.publications .bibtex:not(.hidden) {
+  background: var(--rl-bg-subtle);
+  border: 1px solid var(--rl-border);
+  border-radius: var(--rl-radius-sm);
+  padding: var(--rl-space-3) var(--rl-space-4);
+  margin-top: var(--rl-space-2);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-sm);
+  color: var(--rl-text);
+}
+
+.publications .bibtex:not(.hidden) pre,
+.publications .bibtex:not(.hidden) code {
+  background: transparent;
+  font-family: inherit;
+  color: inherit;
+}


### PR DESCRIPTION
## Phase 5 — system wrap

Final pass extending the token-driven brand system to the remaining surfaces.

### New SCSS partials
- `_sass/custom/_publications.scss` — publications page typography (`.title` / `.author` / `.periodical` / `.links`)
- `_sass/custom/_award-list.scss` — award-year eyebrow chip pattern
- `_sass/custom/_hero-panel-audit.scss` — hero-panel-academic token alignment
- `_sass/custom/_blog-post.scss` — blog post rhythm (`post.liquid` layout)
- `_sass/custom/_cv-page.scss` — CV page typography (`cv.liquid` layout)

### Replaced
- `_sass/custom/_dark-mode.scss` — full rewrite to a token-aware dark-mode hygiene catch-all (419 → 89 net lines after consolidation)

### New
- `BRAND_SYSTEM.md` — root-level consolidated reference describing the token system, components, and where each partial applies

### Notes

- The apply script reported `WARN: could not find Selected awards section in about.md`. The award-list partial is wired in via `_custom.scss`, but `about.md` still needs a manual markup change to use the eyebrow chip pattern. Tracking as a follow-up — not blocking this merge.
- Depends on Phases 1, 2a, 2b, 2c, 4 (all merged to master prior to this PR).
- Idempotent: re-running the apply script on a tree that already has Phase 5 is a no-op.
