### PR TITLE
Phase 6 hotfixes round 1: hero, badges, software head, projects, funding

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -2577,3 +2577,5 @@ a.quick-link:hover {
 @import 'custom/blog-post';
 
 @import 'custom/cv-page';
+
+@import "custom/hotfixes-r1";

--- a/_sass/custom/_hotfixes-r1.scss
+++ b/_sass/custom/_hotfixes-r1.scss
@@ -1,0 +1,336 @@
+/* ==========================================================================
+   PHASE 6 — HOTFIXES ROUND 1
+   --------------------------------------------------------------------------
+   Outstanding visual issues raised in the Phase 5 review.  Loaded LAST in
+   _sass/_custom.scss so these rules win the cascade without rewriting the
+   pre-existing partials they correct.
+
+   Five fixes, scoped to the originating selectors:
+
+     1. Hero panel — restore horizontal padding (was 1.5rem 0)
+     2. Hero panel — switch lead paragraph from serif lede to body sans so
+        copy register matches every other page
+     3. Publications — restore venue-badge color tint (Carolina blue)
+        (Phase 5 over-neutralized to a transparent chip)
+     4. Software/PurIST — compress __head → __desc rhythm so title+hex
+        stop opening a void above the description
+     5. Projects + Funding pages — flatten legacy gradients, lifts,
+        animations, and emoji badges to match the Phase 1–5 academic system
+
+   Token references: see _sass/custom/_tokens.scss for --rl-* definitions.
+   ========================================================================== */
+
+
+/* 1 + 2 ─── Hero panel: padding, gap, sans lead ───────────────────────────── */
+
+.hero-panel--academic {
+  /* Was 1.5rem 0 2rem — zero horizontal padding meant the picture column
+     started at the absolute right edge and the text column at the left. */
+  padding: var(--rl-space-6) var(--rl-space-6) var(--rl-space-7);
+}
+
+.hero-panel__grid {
+  /* Tighter aside column + smaller gap so the gulf between body copy and
+     portrait closes. Aside floor 220px keeps the photo legible. */
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
+  gap: var(--rl-space-5);
+}
+
+.hero-panel__lead {
+  /* Phase 5 set this to --rl-font-serif (the "lede" register from the
+     four-register system). The user reads the hero as inconsistent with
+     other pages, where body copy is sans. Drop the lede treatment and
+     use the body register. Headings (name, role) stay serif. */
+  font-family: var(--rl-font-sans);
+  font-size: var(--rl-text-base);
+  font-style: normal;
+  font-weight: 400;
+  line-height: var(--rl-leading-normal);
+  letter-spacing: 0;
+  max-width: 62ch;
+}
+
+@media (max-width: 768px) {
+  .hero-panel--academic {
+    padding: var(--rl-space-5);
+  }
+  .hero-panel__grid {
+    grid-template-columns: 1fr;
+    gap: var(--rl-space-5);
+  }
+}
+
+
+/* 3 ─── Publications: restore venue-badge color ───────────────────────────── */
+
+/* Phase 5 neutralized .publications .abbr abbr.badge to --rl-bg-subtle /
+   --rl-text-muted, which made the chip nearly invisible. Restore a
+   Carolina-blue tint that reads as a venue badge while still living in the
+   token system. Selectors carry !important to win against bootstrap badge. */
+
+.publications .abbr abbr.badge {
+  background: rgba(75, 156, 211, 0.12) !important;
+  color: #2C5080 !important;             /* Carolina deep — readable on tint */
+  border: 1px solid rgba(75, 156, 211, 0.32) !important;
+  font-weight: 600 !important;
+}
+
+.publications .abbr abbr.badge a {
+  color: inherit !important;
+  text-decoration: none !important;
+}
+
+html[data-theme='dark'] .publications .abbr abbr.badge {
+  background: rgba(75, 156, 211, 0.18) !important;
+  color: #9DC8E8 !important;
+  border-color: rgba(75, 156, 211, 0.4) !important;
+}
+
+
+/* 4 ─── Software/PurIST: tighten __head → __desc ─────────────────────────── */
+
+/* The hex sticker (md ≈ 56–64px) sits beside the H3 in __head. Without an
+   explicit head margin the H3's own bottom margin AND the desc top margin
+   stack with the hex height, opening a visible gap on PurIST (which is
+   alone in its grid so the issue isn't masked by neighbors). Lock the
+   rhythm here. */
+
+.software-card__head {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--rl-space-3);
+  margin: 0 0 var(--rl-space-3);
+}
+
+.software-card__head h3 {
+  margin: 0 !important;
+  flex: 1;
+  min-width: 0;
+  line-height: 1.25;
+}
+
+.software-card__head .hex-mark,
+.software-card__head .hex-sticker,
+.software-card__head svg {
+  flex-shrink: 0;
+  max-width: 56px;
+  height: auto;
+}
+
+.software-card__desc {
+  margin-top: 0 !important;
+}
+
+
+/* 5 ─── Projects + Funding: flatten to academic system ────────────────────── */
+
+/* Both pages still carry the pre-Phase-1 aesthetic: gradient backgrounds,
+   translateY hovers, animated entry delays, accent-stripe ::before bars,
+   and emoji badge content. Strip these and re-set the cards to the same
+   token-driven flat surface used by .software-card / .recognition-card
+   after Phase 1. */
+
+
+/* ── Project cards ──────────────────────────────────────────────────────── */
+
+.project-card {
+  background: var(--rl-bg) !important;
+  border: 1px solid var(--rl-border) !important;
+  border-radius: var(--rl-radius-md) !important;
+  box-shadow: none !important;
+  padding: var(--rl-space-5) !important;
+  animation: none !important;
+  transform: none !important;
+  transition: border-color 160ms ease, background 160ms ease !important;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.project-card:hover {
+  transform: none !important;
+  box-shadow: none !important;
+  border-color: var(--rl-border-strong) !important;
+  background: var(--rl-bg-subtle) !important;
+}
+
+.project-card::before,
+.project-card:hover::before {
+  display: none !important;
+  content: none !important;
+}
+
+.project-card h3 {
+  color: var(--rl-heading) !important;
+  font-family: var(--rl-font-serif) !important;
+  font-size: var(--rl-text-md) !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.01em;
+  margin: 0 0 var(--rl-space-3) !important;
+}
+
+.project-card > p {
+  color: var(--rl-text) !important;
+  font-family: var(--rl-font-sans) !important;
+  font-size: var(--rl-text-base) !important;
+  line-height: var(--rl-leading-normal) !important;
+  margin: 0 0 var(--rl-space-3) !important;
+}
+
+.project-meta {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--rl-space-3);
+  font-family: var(--rl-font-sans);
+  font-size: var(--rl-text-sm);
+  color: var(--rl-text-muted);
+}
+
+.project-meta li {
+  margin-bottom: 0.2rem;
+}
+
+.project-meta strong {
+  color: var(--rl-text);
+  font-weight: 600;
+}
+
+.project-card__links {
+  margin-top: auto;
+  padding-top: var(--rl-space-3);
+  border-top: 1px solid var(--rl-border);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 var(--rl-space-3);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  letter-spacing: 0.02em;
+}
+
+.project-card__links a {
+  color: var(--rl-link);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 160ms ease, color 160ms ease;
+}
+
+.project-card__links a:hover {
+  color: var(--rl-link-hover);
+  border-bottom-color: currentColor;
+}
+
+/* Replace gradient accent stripe with a calm 3px left border */
+.project-card--pilot { border-left: 3px solid #4B9CD3 !important; }
+.project-card--adopt { border-left: 3px solid #2d8a63 !important; }
+.project-card--story { border-left: 3px solid #6d28d9 !important; }
+
+/* Project badges: drop emoji + gradient pills */
+.project-card__badge {
+  background: var(--rl-bg-subtle) !important;
+  color: var(--rl-text) !important;
+  font-family: var(--rl-font-mono) !important;
+  font-size: var(--rl-text-xs) !important;
+  font-weight: 500 !important;
+  border: 1px solid var(--rl-border) !important;
+  border-radius: 3px !important;
+  padding: 0.18rem 0.55rem !important;
+}
+
+.project-card__badge::before {
+  content: none !important;
+}
+
+
+/* ── Grant cards ────────────────────────────────────────────────────────── */
+
+.grant-card {
+  background: var(--rl-bg) !important;
+  border: 1px solid var(--rl-border) !important;
+  border-radius: var(--rl-radius-md) !important;
+  box-shadow: none !important;
+  transform: none !important;
+  transition: border-color 160ms ease !important;
+}
+
+.grant-card:hover {
+  transform: none !important;
+  box-shadow: none !important;
+  border-color: var(--rl-border-strong) !important;
+}
+
+.grant-card--featured {
+  border-left: 3px solid #4B9CD3 !important;
+  background: var(--rl-bg) !important;
+}
+
+.grant-card--featured::before {
+  display: none !important;
+  content: none !important;
+}
+
+.grant-card__header h3 {
+  color: var(--rl-heading) !important;
+  font-family: var(--rl-font-serif) !important;
+  font-weight: 600 !important;
+}
+
+.grant-card__header .badge-success {
+  background: var(--rl-bg-subtle) !important;
+  color: var(--rl-text) !important;
+  border: 1px solid var(--rl-border) !important;
+  font-family: var(--rl-font-mono) !important;
+  font-weight: 500 !important;
+  text-shadow: none !important;
+}
+
+.grant-card__description {
+  color: var(--rl-text) !important;
+  font-family: var(--rl-font-sans) !important;
+}
+
+.grant-detail__label {
+  font-family: var(--rl-font-mono) !important;
+  font-size: var(--rl-text-xs) !important;
+  color: var(--rl-text-muted) !important;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.grant-detail__value {
+  font-family: var(--rl-font-sans) !important;
+  color: var(--rl-text) !important;
+}
+
+
+/* ── Funding accordion ──────────────────────────────────────────────────── */
+
+.funding-accordion {
+  background: var(--rl-bg) !important;
+  border: 1px solid var(--rl-border) !important;
+  border-radius: var(--rl-radius-md) !important;
+  box-shadow: none !important;
+}
+
+.funding-accordion summary {
+  background: var(--rl-bg-subtle) !important;
+  font-family: var(--rl-font-sans) !important;
+  font-weight: 600 !important;
+  color: var(--rl-text) !important;
+}
+
+.funding-accordion summary:hover {
+  background: var(--rl-border) !important;
+}
+
+.funding-accordion[open] summary {
+  border-bottom: 1px solid var(--rl-border) !important;
+}
+
+
+/* ── Funding timeline (top-of-page banner) ──────────────────────────────── */
+
+.funding-timeline {
+  background: var(--rl-bg-subtle) !important;
+  border: 1px solid var(--rl-border) !important;
+  box-shadow: none !important;
+}


### PR DESCRIPTION
## Phase 6 — hotfixes round 1

Five visual fixes from Phase 5 review, loaded as a single trailing partial (`_sass/custom/_hotfixes-r1.scss`) so they win the cascade without touching prior phase work.

### Fixes

1. **Hero panel padding restored** — `.hero-panel--academic` was `1.5rem 0 2rem` (zero horizontal). Now `var(--rl-space-6)`. Portrait no longer sits flush at the right edge.
1b. **Aside column tightened** — `.hero-panel__grid` columns → `minmax(220px, 280px)`, gap → `--rl-space-5`. Closed the stranded whitespace.
2. **Hero lead font** — `.hero-panel__lead` switched from `--rl-font-serif` to `--rl-font-sans`, body size, no italics. Matches body register on every other page.
3. **Publications venue badges** — `.publications .abbr abbr.badge` regains a Carolina-blue tint background + Carolina-deep text + dark-mode variant (was nearly-invisible gray after Phase 5).
4. **Software card head→desc rhythm** — `.software-card__head` margins locked to `0 0 var(--rl-space-3)`; hex sticker clamped to 56px. PurIST card no longer opens a large gap.
5. **Projects + Funding flatten** — `.project-card`, `.grant-card`, `.funding-accordion`, `.funding-timeline` lose gradient backgrounds, `translateY` lifts, entry animations, accent `::before` stripes, and emoji-prefixed badges. Stage stripes replaced with calm 3px left borders. `.grant-card--featured` gets a 3px Carolina left border.

### Verified in browser

Each fix verified via local Jekyll preview + DOM inspection. All five surfaces deliver the spec'd computed styles.

### Notes

- Built on top of merged Phase 5; no rebase needed.
- Patch overrides legacy `_aesthetic-refinements.scss` rules via specificity + `!important` at leaf selectors. A proper refactor of that 2200-line file is deferred to Phase 7+.
- If new issues surface, batch them into `_hotfixes-r2.scss` rather than editing this partial. Each round = one branch = one PR.
