### PR TITLE
Phase 6 imagery: figure treatment + downloadable hex stickers

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -2578,4 +2578,6 @@ a.quick-link:hover {
 
 @import 'custom/cv-page';
 
+@import "custom/figures";
+
 @import "custom/hotfixes-r1";

--- a/_sass/custom/_figures.scss
+++ b/_sass/custom/_figures.scss
@@ -1,0 +1,98 @@
+/* ==========================================================================
+   FIGURE TREATMENT — PHASE 6
+   --------------------------------------------------------------------------
+   Academic figure styling for `_includes/figure.liquid` output and any
+   <figure>/<figcaption> markup in prose pages and blog posts.
+
+   Goal: photos and diagrams sit in a hairline frame with serif italic
+   captions, tabular figure numbering optional. No drop shadows, no
+   rounded-corner overlays, no hover lifts.
+
+   Selectors are scoped to .post and .post-content so we don't rewrite
+   bootstrap card images or hex stickers (which have their own treatments).
+   ========================================================================== */
+
+.post figure,
+.post-content > figure {
+  margin: var(--rl-space-6) auto;
+  max-width: 100%;
+  text-align: center;
+
+  /* The image itself: hairline border, no radius (academic, not social-card) */
+  > picture > img,
+  > img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: 0 auto;
+    border: 1px solid var(--rl-border);
+    background: var(--rl-bg);
+  }
+
+  /* Caption — serif italic, muted, max-width matching prose measure */
+  > figcaption,
+  > .caption {
+    color: var(--rl-text-muted);
+    font-family: var(--rl-font-serif);
+    font-size: var(--rl-text-sm);
+    font-style: italic;
+    font-weight: 400;
+    line-height: var(--rl-leading-normal);
+    text-align: left;
+    max-width: 65ch;
+    margin: var(--rl-space-3) auto 0;
+    padding: 0 var(--rl-space-1);
+
+    /* "Figure 1." prefix if the caption begins with one — bold + non-italic */
+    > strong:first-child,
+    > b:first-child {
+      color: var(--rl-text);
+      font-style: normal;
+      font-weight: 600;
+      font-family: var(--rl-font-mono);
+      font-size: var(--rl-text-xs);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      margin-right: var(--rl-space-2);
+    }
+  }
+}
+
+/* ----- Inline image inside prose (no <figure>) ----------------------------
+   Images dropped straight into markdown prose — give them the same border
+   so the page doesn't have two visual treatments. */
+.post-content > p > img,
+.post > p > img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: var(--rl-space-5) auto;
+  border: 1px solid var(--rl-border);
+  background: var(--rl-bg);
+}
+
+/* ----- Hex sticker download link on software cards ------------------------
+   Tiny mono link rendered after .software-card__pill list. Wired up by the
+   apply script as `<a class="software-card__download" href="...">`. */
+.software-card__download {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--rl-space-1);
+  margin-top: var(--rl-space-2);
+  color: var(--rl-text-muted);
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--rl-border-strong);
+  padding-bottom: 1px;
+
+  &::before { content: "↓"; opacity: 0.7; }
+
+  &:hover {
+    color: var(--rl-link-hover);
+    border-bottom-color: var(--rl-link-hover);
+  }
+}

--- a/assets/img/hex/baton.svg
+++ b/assets/img/hex/baton.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 174 200" width="174" height="200">
+  <title>BATON — Rashid Lab hex sticker</title>
+  <polygon points="87,2 170,50 170,150 87,198 4,150 4,50" fill="#0B1D3A"></polygon>
+  <polygon points="87,2 170,50 170,150 87,198 4,150 4,50" fill="none" stroke="#4B9CD3" stroke-width="4" stroke-linejoin="round"></polygon>
+  <polygon points="87,10 163,54 163,146 87,190 11,146 11,54" fill="none" stroke="#4B9CD3" stroke-opacity=".35" stroke-width="1"></polygon>
+  <g fill="none" stroke="#4B9CD3" stroke-linejoin="round">
+    <ellipse cx="87" cy="132" rx="46" ry="7" stroke-opacity=".22" stroke-width="1"></ellipse>
+    <ellipse cx="87" cy="130" rx="30" ry="5" stroke-opacity=".32" stroke-width="1"></ellipse>
+    <ellipse cx="87" cy="128" rx="16" ry="2.6" stroke-opacity=".5" stroke-width="1"></ellipse>
+  </g>
+  <path d="M 43 118 C 65 118 75 60 87 60 C 99 60 109 118 131 118" fill="#4B9CD3" fill-opacity=".14" stroke="#4B9CD3" stroke-width="2" stroke-linejoin="round"></path>
+  <path d="M 42 126 C 56 150 118 150 138 122 C 158 96 110 76 87 60" fill="none" stroke="#C48A1A" stroke-opacity=".9" stroke-width="1.25" stroke-dasharray="3,2" stroke-linecap="round"></path>
+  <g fill="#C48A1A">
+    <circle cx="60" cy="139" r="1.5"></circle>
+    <circle cx="122" cy="135" r="1.5"></circle>
+    <circle cx="121" cy="81" r="1.5"></circle>
+  </g>
+  <path d="M 50 34 Q 66 22 87 60" fill="none" stroke="#4B9CD3" stroke-opacity=".4" stroke-width="1" stroke-dasharray="2.5,2.5"></path>
+  <line x1="54" y1="42" x2="87" y2="60" stroke="#F4F6F8" stroke-width="2.75" stroke-linecap="round"></line>
+  <circle cx="50" cy="40" r="4.25" fill="#C48A1A" stroke="#F4F6F8" stroke-width="1"></circle>
+  <circle cx="87" cy="60" r="6" fill="none" stroke="#F4F6F8" stroke-opacity=".35" stroke-width="1"></circle>
+  <circle cx="87" cy="60" r="3" fill="#F4F6F8"></circle>
+  <g stroke="#F4F6F8" stroke-width="1.25" stroke-linecap="round">
+    <line x1="87" y1="52" x2="87" y2="48"></line>
+    <line x1="91" y1="55" x2="95" y2="51"></line>
+    <line x1="93" y1="60" x2="98" y2="60"></line>
+    <line x1="91" y1="65" x2="95" y2="69"></line>
+    <line x1="87" y1="68" x2="87" y2="72"></line>
+  </g>
+  <line x1="30" y1="152" x2="144" y2="152" stroke="#4B9CD3" stroke-opacity=".4" stroke-width="1"></line>
+  <text x="87" y="166" text-anchor="middle" font-family="Archivo, Helvetica, system-ui, sans-serif" font-size="20" font-weight="600" letter-spacing="3" fill="#F4F6F8">BATON</text>
+</svg>

--- a/assets/img/hex/desurv.svg
+++ b/assets/img/hex/desurv.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 174 200" width="174" height="200">
+  <title>DeSurv — Rashid Lab hex sticker</title>
+  <polygon points="87,2 170,50 170,150 87,198 4,150 4,50" fill="#0B1D3A"></polygon>
+  <polygon points="87,2 170,50 170,150 87,198 4,150 4,50" fill="none" stroke="#4B9CD3" stroke-width="4" stroke-linejoin="round"></polygon>
+  <polygon points="87,10 163,54 163,146 87,190 11,146 11,54" fill="none" stroke="#4B9CD3" stroke-opacity=".35" stroke-width="1"></polygon>
+  <line x1="28" y1="38" x2="28" y2="134" stroke="#4B9CD3" stroke-opacity=".3" stroke-width="1"></line>
+  <line x1="28" y1="134" x2="150" y2="134" stroke="#4B9CD3" stroke-opacity=".3" stroke-width="1"></line>
+  <path d="M 28 46 L 52 46 L 52 60 L 74 60 L 74 78 L 98 78 L 98 98 L 122 98 L 122 114 L 150 114" fill="none" stroke="#4B9CD3" stroke-width="2.5" stroke-linejoin="miter" stroke-linecap="round"></path>
+  <g stroke="#4B9CD3" stroke-width="1.5" stroke-linecap="round">
+    <line x1="40" y1="42" x2="40" y2="50"></line>
+    <line x1="64" y1="56" x2="64" y2="64"></line>
+    <line x1="86" y1="74" x2="86" y2="82"></line>
+    <line x1="110" y1="94" x2="110" y2="102"></line>
+    <line x1="134" y1="110" x2="134" y2="118"></line>
+  </g>
+  <g stroke="#C48A1A" stroke-width="2" stroke-linecap="round">
+    <line x1="52" y1="62" x2="52" y2="70"></line>
+    <line x1="74" y1="80" x2="74" y2="88"></line>
+    <line x1="98" y1="100" x2="98" y2="108"></line>
+    <line x1="122" y1="116" x2="122" y2="124"></line>
+  </g>
+  <line x1="30" y1="152" x2="144" y2="152" stroke="#4B9CD3" stroke-opacity=".4" stroke-width="1"></line>
+  <text x="87" y="166" text-anchor="middle" font-family="Archivo, Helvetica, system-ui, sans-serif" font-size="20" font-weight="600" letter-spacing="2" fill="#F4F6F8">DeSurv</text>
+</svg>

--- a/assets/img/hex/evolvetrial.svg
+++ b/assets/img/hex/evolvetrial.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 174 200" width="174" height="200">
+  <title>evolveTrial — Rashid Lab hex sticker</title>
+  <polygon points="87,2 170,50 170,150 87,198 4,150 4,50" fill="#0B1D3A"></polygon>
+  <polygon points="87,2 170,50 170,150 87,198 4,150 4,50" fill="none" stroke="#4B9CD3" stroke-width="4" stroke-linejoin="round"></polygon>
+  <polygon points="87,10 163,54 163,146 87,190 11,146 11,54" fill="none" stroke="#4B9CD3" stroke-opacity=".35" stroke-width="1"></polygon>
+  <line x1="26" y1="132" x2="150" y2="132" stroke="#4B9CD3" stroke-opacity=".3" stroke-width="1"></line>
+  <line x1="26" y1="48" x2="150" y2="48" stroke="#C48A1A" stroke-opacity=".75" stroke-width="1.25" stroke-dasharray="4,2"></line>
+  <line x1="26" y1="112" x2="150" y2="112" stroke="#C48A1A" stroke-opacity=".5" stroke-width="1.25" stroke-dasharray="4,2"></line>
+  <circle cx="28" cy="82" r="2.5" fill="#4B9CD3"></circle>
+  <g fill="none" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M 28 82 L 50 78 L 72 85 L 94 78 L 116 82 L 138 80" stroke="#4B9CD3" stroke-opacity=".4" stroke-width="1.25"></path>
+    <path d="M 28 82 L 50 72 L 72 62 L 94 48" stroke="#4B9CD3" stroke-width="1.75"></path>
+    <path d="M 28 82 L 50 90 L 72 100 L 94 112" stroke="#4B9CD3" stroke-opacity=".55" stroke-width="1.25" stroke-dasharray="2,2"></path>
+    <path d="M 28 82 L 50 85 L 72 80 L 94 87 L 116 82 L 138 86" stroke="#4B9CD3" stroke-opacity=".4" stroke-width="1.25"></path>
+    <path d="M 28 82 L 50 76 L 72 68 L 94 60 L 116 52 L 124 48" stroke="#4B9CD3" stroke-width="1.75"></path>
+  </g>
+  <circle cx="94" cy="48" r="3.75" fill="#C48A1A"></circle>
+  <circle cx="124" cy="48" r="3.75" fill="#C48A1A"></circle>
+  <circle cx="94" cy="112" r="3.75" fill="none" stroke="#C48A1A" stroke-width="1.75"></circle>
+  <line x1="30" y1="152" x2="144" y2="152" stroke="#4B9CD3" stroke-opacity=".4" stroke-width="1"></line>
+  <text x="87" y="166" text-anchor="middle" font-family="Archivo, Helvetica, system-ui, sans-serif" font-size="18" font-weight="600" letter-spacing="1.5" fill="#F4F6F8">evolveTrial</text>
+</svg>

--- a/assets/img/hex/purist.svg
+++ b/assets/img/hex/purist.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 174 200" width="174" height="200">
+  <title>PurIST — Rashid Lab hex sticker</title>
+  <polygon points="87,2 170,50 170,150 87,198 4,150 4,50" fill="#0B1D3A"></polygon>
+  <polygon points="87,2 170,50 170,150 87,198 4,150 4,50" fill="none" stroke="#4B9CD3" stroke-width="4" stroke-linejoin="round"></polygon>
+  <polygon points="87,10 163,54 163,146 87,190 11,146 11,54" fill="none" stroke="#4B9CD3" stroke-opacity=".35" stroke-width="1"></polygon>
+  <line x1="36" y1="30" x2="36" y2="134" stroke="#4B9CD3" stroke-opacity=".3" stroke-width="1"></line>
+  <line x1="36" y1="134" x2="146" y2="134" stroke="#4B9CD3" stroke-opacity=".3" stroke-width="1"></line>
+  <line x1="36" y1="134" x2="140" y2="30" stroke="#F4F6F8" stroke-opacity=".5" stroke-width="1.5" stroke-dasharray="4,3"></line>
+  <g fill="#4B9CD3">
+    <circle cx="54" cy="44" r="3.25"></circle>
+    <circle cx="66" cy="56" r="3.25"></circle>
+    <circle cx="76" cy="46" r="3.25"></circle>
+    <circle cx="80" cy="64" r="3.25"></circle>
+    <circle cx="92" cy="68" r="3.25"></circle>
+    <circle cx="56" cy="72" r="3.25"></circle>
+    <circle cx="102" cy="82" r="3.25"></circle>
+  </g>
+  <g fill="#C48A1A">
+    <circle cx="96" cy="110" r="3.25"></circle>
+    <circle cx="108" cy="98" r="3.25"></circle>
+    <circle cx="120" cy="112" r="3.25"></circle>
+    <circle cx="130" cy="122" r="3.25"></circle>
+    <circle cx="114" cy="120" r="3.25"></circle>
+    <circle cx="86" cy="118" r="3.25"></circle>
+    <circle cx="134" cy="108" r="3.25"></circle>
+  </g>
+  <line x1="30" y1="152" x2="144" y2="152" stroke="#4B9CD3" stroke-opacity=".4" stroke-width="1"></line>
+  <text x="87" y="166" text-anchor="middle" font-family="Archivo, Helvetica, system-ui, sans-serif" font-size="20" font-weight="600" letter-spacing="2" fill="#F4F6F8">PurIST</text>
+</svg>


### PR DESCRIPTION
## Phase 6 — imagery pass

### What this adds

- **`_sass/custom/_figures.scss`** — academic figure treatment scoped to `.post` and `.post-content`:
  - Hairline border on `figure > img` (no shadow, no radius)
  - Source Serif 4 italic figcaption, slate-400 muted, left-aligned, capped at 65ch
  - IBM Plex Mono uppercase eyebrow for `<strong>Figure N.</strong>` prefix when present
  - Inline `<p><img></p>` images inherit the same hairline frame
  - `.software-card__download` mono chip styling for downloadable-sticker links
- **`assets/img/hex/{baton,desurv,purist,evolvetrial}.svg`** — standalone downloadable hex stickers (174×200 viewBox = R-community 5.08×5.87cm spec). Already serving locally with HTTP 200.

### Wiring note (additional commit on this branch)

The apply script auto-wires `@import 'figures'` into `_sass/custom/_main.scss` between Phase 1 markers. This repo doesn't have `_main.scss` — Phase 1 wired everything through `_sass/_custom.scss` instead — so the script printed a warning and skipped. A second commit on this branch adds the `@import "custom/figures";` line to `_sass/_custom.scss`, ordered just before `hotfixes-r1` so the trailing hotfix patch keeps cascade-last authority.

### To expose download links on `/software/`

Markup change required (deferred — not in this PR):

```html
<a class="software-card__download"
   href="{{ '/assets/img/hex/baton.svg' | relative_url }}"
   download>Sticker SVG</a>
```

### Verified

- All `_figures.scss` selectors loaded into the compiled CSS (probed via DOM injection)
- Computed styles match the spec on a synthetic `<figure>` test element
- All 4 hex SVGs serve from `/assets/img/hex/*.svg` (HTTP 200)
