### PR TITLE
Phase 7 hotfixes round 2: blog listing, team headings, repositories gap

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -2581,3 +2581,5 @@ a.quick-link:hover {
 @import "custom/figures";
 
 @import "custom/hotfixes-r1";
+
+@import "custom/hotfixes-r2";

--- a/_sass/custom/_hotfixes-r2.scss
+++ b/_sass/custom/_hotfixes-r2.scss
@@ -1,0 +1,121 @@
+/* ==========================================================================
+   PHASE 7 — HOTFIXES ROUND 2
+   --------------------------------------------------------------------------
+   Audit-driven fixes for surfaces the Phase 1–6 system missed:
+     1. Blog listing  /blog/         — header bar h1, post-title font, meta
+                                        eyebrow, tag links
+     2. Team page     /team/         — group h3 in serif, resting card shadow
+     3. Repositories  /repositories/ — flex-container gap
+
+   Loaded after _hotfixes-r1 in _sass/_custom.scss so r1 retains cascade-last
+   authority on the surfaces it claims (projects, funding). r2 only touches
+   surfaces r1 didn't.
+   ========================================================================== */
+
+
+/* --------------------------------------------------------------------------
+   1. /blog/ — listing page
+   -------------------------------------------------------------------------- */
+
+/* 1a. .header-bar h1: cap from al-folio default (was 80px Carolina blue). */
+.header-bar h1 {
+  font-size: var(--rl-text-2xl) !important;     /* 36px */
+  color: var(--rl-heading) !important;
+  line-height: var(--rl-leading-tight);
+  margin-bottom: var(--rl-space-2);
+}
+
+.header-bar h2 {
+  font-family: var(--rl-font-sans) !important;
+  font-size: var(--rl-text-base) !important;
+  font-weight: 400;
+  font-style: normal;
+  color: var(--rl-text-muted) !important;
+}
+
+/* 1b. .post-list post titles: serif heading register (was Archivo 32px). */
+.post-list > li > h3 {
+  margin-top: var(--rl-space-5);
+  margin-bottom: var(--rl-space-2);
+}
+
+.post-list > li > h3 .post-title,
+.post-list > li > h3 > a {
+  font-family: var(--rl-font-serif) !important;
+  font-size: var(--rl-text-lg) !important;       /* 22px */
+  font-weight: 600;
+  color: var(--rl-heading) !important;
+  line-height: var(--rl-leading-tight);
+  text-decoration: none;
+  letter-spacing: 0;
+}
+
+.post-list > li > h3 .post-title:hover,
+.post-list > li > h3 > a:hover {
+  color: var(--rl-link-hover) !important;
+  text-decoration: underline;
+}
+
+/* 1c. .post-meta: mono uppercase eyebrow (was Archivo 14px medium gray). */
+.post-list > li > .post-meta {
+  font-family: var(--rl-font-mono) !important;
+  font-size: var(--rl-text-xs) !important;        /* 12px */
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--rl-text-muted) !important;
+  font-weight: 500;
+  margin-bottom: var(--rl-space-2);
+}
+
+/* 1d. .post-tags: mono caps row, no chip frame (lives in dot-separated cluster). */
+.post-list > li > .post-tags {
+  font-family: var(--rl-font-mono);
+  font-size: var(--rl-text-xs);
+  margin-bottom: var(--rl-space-5);
+}
+
+.post-list > li > .post-tags a {
+  color: var(--rl-text-muted) !important;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.post-list > li > .post-tags a:hover {
+  color: var(--rl-link-hover) !important;
+  text-decoration: underline;
+}
+
+
+/* --------------------------------------------------------------------------
+   2. /team/ — group headings + resting card shadow
+   -------------------------------------------------------------------------- */
+
+/* 2a. .team-group-block__header h3: bring "Faculty", "Current Students" etc.
+       into the serif heading hierarchy. Was Archivo 20px. */
+.team-group-block__header h3 {
+  font-family: var(--rl-font-serif) !important;
+  font-size: var(--rl-text-lg) !important;        /* 22px */
+  font-weight: 600;
+  color: var(--rl-heading) !important;
+  line-height: var(--rl-leading-tight);
+}
+
+/* 2b. .team-member-card resting shadow: tighten from 0 8px 20px (pre-Phase-1
+       lift aesthetic) to --rl-shadow-sm. Existing :hover rule on
+       .team-member-card already lifts to --rl-shadow-md, so the resting
+       state was actually larger than the hover state. */
+.team-member-card {
+  box-shadow: var(--rl-shadow-sm) !important;
+}
+
+
+/* --------------------------------------------------------------------------
+   3. /repositories/ — flex container gap
+   -------------------------------------------------------------------------- */
+
+/* 3. .repositories has gap: normal (default 0). Add token spacing so the
+      github-readme-stats embeds don't touch. */
+.repositories {
+  gap: var(--rl-space-4);
+}


### PR DESCRIPTION
## Phase 7 — hotfixes round 2

Audit-driven fixes for the three surfaces the Phase 1–6 system missed. Loaded after `_hotfixes-r1` in `_sass/_custom.scss` so r1 retains cascade-last authority on its claimed surfaces (projects, funding); r2 only touches surfaces r1 didn't.

### 1. `/blog/` listing — major divergence corrected

| Element | Before | After |
|---|---|---|
| `.header-bar h1` | 80px Source Serif 4 in Carolina blue (al-folio default) | 36px (`--rl-text-2xl`) in `--rl-heading` |
| `.header-bar h2` | larger / italic styling | Archivo 16px (`--rl-text-base`) muted |
| `.post-list h3 .post-title` | Archivo 32px | Source Serif 4 22px (`--rl-text-lg`) 600 |
| `.post-list .post-meta` | Archivo 14px medium gray | IBM Plex Mono 12px uppercase muted |
| `.post-list .post-tags a` | plain text | IBM Plex Mono 12px uppercase muted |

Phase 5's `_blog-post.scss` styled individual posts but never touched the listing — this fills that gap.

### 2. `/team/` — minor

- `.team-group-block__header h3` (Faculty / Current Students / etc.) was Archivo 20px — now Source Serif 22px 600, matching the heading hierarchy.
- `.team-member-card` resting `box-shadow` was `0 8px 20px rgba(15, 23, 42, 0.08)` (pre-Phase-1 lift aesthetic). Hover transitions to `--rl-shadow-md`, so the resting state was actually *larger* than the hover state. Changed resting to `--rl-shadow-sm`.

### 3. `/repositories/` — minor

- `.repositories` flex container had `gap: normal` (browser default 0); github-readme-stats embeds were touching. Added `gap: var(--rl-space-4)`.

### Verified

Each of the 8 changes verified via DOM inspection in local Jekyll preview. No markup changes, just CSS additions in a new partial.

### Cascade order in `_sass/_custom.scss`

```
... figures
... hotfixes-r1   (projects, funding, hero, badges, software head)
... hotfixes-r2   (blog listing, team headings, repos gap)  ← new
```
